### PR TITLE
Update dark theme and fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,30 @@
 *   CSS3 (с CSS Custom Properties / Variables)
 *   JavaScript (ES6+)
 *   [Font Awesome](https://fontawesome.com/) (за икони)
-*   [Google Fonts](https://fonts.google.com/) (Playfair Display & Lato)
+*   [Google Fonts](https://fonts.google.com/) (Poppins & Inter)
 
 ## Структура на проекта
 
 *   `main.html`: Основната HTML структура на страницата.
 *   `style.css`: Всички CSS стилове за визията на сайта.
 *   `script.js`: JavaScript код за интерактивност, смяна на тема, мобилно меню и анимации.
+
+## Персонализиране
+
+Променливите за цветовата тема се намират в началото на `style.css`. Там са
+дефинирани и стойностите за тъмния режим, например:
+
+```css
+:root {
+    /* Dark theme variables */
+    --bg-primary-dark: #121212;
+    --bg-secondary-dark: #1e1e1e;
+    /* ... */
+}
+```
+
+Шрифтовете се зареждат чрез Google Fonts в `main.html`. Могат да бъдат сменени,
+като се редактира `<link>` елемента и свойствата `font-family` в `style.css`.
 
 ## Как да разгледате сайта
 

--- a/main.html
+++ b/main.html
@@ -5,14 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>IntoDesign Studio | Персонализирани интериорни решения</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Lato:wght@300;400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <!-- Header -->
     <header>
         <div class="container header-container">
-            <a href="#" class="logo">IntoDesign</a>
+            <a href="#" class="logo">
+                <div class="logo-main">
+                    <span class="logo-box">I</span>
+                    <span class="logo-box">N</span>
+                    <span class="logo-box">T</span>
+                    <span class="logo-box">O</span>
+                </div>
+                <span class="logo-sub">design studio</span>
+            </a>
             
             <nav>
                 <div class="nav-links">

--- a/style.css
+++ b/style.css
@@ -12,12 +12,12 @@
     --nav-bg: rgba(248, 248, 246, 0.95);
     
     /* Dark theme variables */
-    --bg-primary-dark: #1a1a1a;
-    --bg-secondary-dark: #252525;
-    --text-primary-dark: #f0f0f0;
-    --text-secondary-dark: #b0b0b0;
-    --accent-primary-dark: #d4b88c;
-    --accent-secondary-dark: #a9926d;
+    --bg-primary-dark: #121212;
+    --bg-secondary-dark: #1e1e1e;
+    --text-primary-dark: #e0e0e0;
+    --text-secondary-dark: #9ca1a6;
+    --accent-primary-dark: #c69c6d;
+    --accent-secondary-dark: #a68055;
     --overlay-dark: rgba(26, 26, 26, 0.9);
     --shadow-dark: rgba(0, 0, 0, 0.2);
     --card-bg-dark: #2d2d2d;
@@ -39,7 +39,7 @@
 }
 
 body {
-    font-family: 'Lato', sans-serif;
+    font-family: 'Inter', sans-serif;
     background-color: var(--bg-primary);
     color: var(--text-primary);
     line-height: 1.6;
@@ -52,7 +52,7 @@ body.dark-theme {
 }
 
 h1, h2, h3, h4, h5 {
-    font-family: 'Playfair Display', serif;
+    font-family: 'Poppins', sans-serif;
     font-weight: 600;
     line-height: 1.2;
 }
@@ -99,14 +99,37 @@ body.dark-theme header {
 }
 
 .logo {
-    font-family: 'Playfair Display', serif;
+    font-family: 'Poppins', sans-serif;
     font-size: 1.8rem;
     font-weight: 700;
-    color: var(--accent-primary);
+    color: var(--text-primary);
+    display: inline-flex;
+    flex-direction: column;
+    line-height: 1;
 }
 
 body.dark-theme .logo {
-    color: var(--accent-primary-dark);
+    color: var(--text-primary-dark);
+}
+
+.logo-box {
+    display: inline-block;
+    border: 1px solid currentColor;
+    margin-right: 2px;
+    padding: 0 4px;
+    font-weight: 700;
+}
+
+.logo-main {
+    display: flex;
+}
+
+.logo-sub {
+    display: block;
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    margin-top: 2px;
+    text-transform: lowercase;
 }
 
 .nav-links {
@@ -575,7 +598,7 @@ body.dark-theme .form-group label {
     padding: 0.75rem;
     border: 1px solid var(--accent-secondary);
     border-radius: var(--border-radius);
-    font-family: 'Lato', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 1rem;
     background-color: var(--bg-secondary); /* Use secondary for inputs to distinguish from primary bg */
     color: var(--text-primary);
@@ -815,6 +838,10 @@ body.dark-theme .mobile-toggle {
         font-size: 2.8rem;
     }
 
+    .logo {
+        font-size: 1.5rem;
+    }
+
     .section-title h2 {
         font-size: 2rem;
     }
@@ -823,6 +850,10 @@ body.dark-theme .mobile-toggle {
 @media (max-width: 576px) {
     .hero h1 {
         font-size: 2.2rem;
+    }
+
+    .logo {
+        font-size: 1.3rem;
     }
 
     .portfolio-grid,


### PR DESCRIPTION
## Summary
- refresh dark color palette
- switch to Inter and Poppins fonts
- redesign logo with square letters
- document how to customize colors and fonts
- refine logo layout and responsive sizing

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842539752508326a2b2cf631256b9a5