### PR TITLE
Fix chat page endpoint

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1,5 +1,5 @@
-const apiEndpoint = 'https://api.cloudflare.com/client/v4/accounts/c2015f4060e04bc3c414f78a9946668e/ai/run/@cf/meta/llama-3-8b-instruct
-
+// URL на бекенда, който препраща заявките към Cloudflare Workers AI
+const apiEndpoint = 'https://openapichatbot.radilov-k.workers.dev/';
 let apiToken = sessionStorage.getItem('apiToken') || '';
 const tokenInput = document.getElementById('api-token');
 const saveTokenBtn = document.getElementById('save-token');


### PR DESCRIPTION
## Summary
- fix broken API endpoint in `chat.js` by setting it to the backend at `https://openapichatbot.radilov-k.workers.dev/`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684e041cf01883268af1fbd649e408ae