### PR TITLE
Improve error handling for fetch

### DIFF
--- a/worker-backend.js
+++ b/worker-backend.js
@@ -25,14 +25,25 @@ export default {
     const messages = data.messages || [];
     const cfEndpoint = `https://api.cloudflare.com/client/v4/accounts/${env.ACCOUNT_ID}/ai/run/${env.MODEL}`;
 
-    const response = await fetch(cfEndpoint, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${env.AI_TOKEN}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ messages })
-    });
+    let response;
+    try {
+      response = await fetch(cfEndpoint, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${env.AI_TOKEN}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ messages })
+      });
+    } catch (err) {
+      return new Response(JSON.stringify({ error: 'Request failed' }), {
+        status: 500,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*'
+        }
+      });
+    }
 
     const result = await response.text();
     return new Response(result, {


### PR DESCRIPTION
## Summary
- wrap `fetch` call in worker backend with try/catch
- return 500 with JSON error when request fails

## Testing
- `node -e "require('./worker-backend.js'); console.log('loaded');"`

------
https://chatgpt.com/codex/tasks/task_e_684e1447b848832693ef6f5b1bb5a6f1