### PR TITLE
Improve debate prompts and mobile layout

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -185,6 +185,17 @@ body {
     border-radius: 0;
   }
 
+  .chat-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .controls {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
   .chat-header h1 {
     font-size: 0.95rem;
   }


### PR DESCRIPTION
## Summary
- switch debate characters to Платон and Ницше and update prompts
- show the speakers' names in the conversation
- tweak responsive styles for phone screens

## Testing
- `node --check chat.js`


------
https://chatgpt.com/codex/tasks/task_e_684ee98ee1308326aa9fb107519ea9ec