### PR TITLE
Add custom bot names

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -209,3 +209,65 @@ body {
     padding: 0 12px;
   }
 }
+
+.settings-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+.settings-btn:hover {
+  color: #0b73ff;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #1e1e1e;
+  padding: 20px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+}
+
+.modal-content h2 {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.modal-content label {
+  display: block;
+  margin-bottom: 10px;
+}
+
+.modal-content input,
+.modal-content textarea {
+  width: 100%;
+  background: #2e2e2e;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 5px;
+  border-radius: 4px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}

--- a/chat.html
+++ b/chat.html
@@ -22,6 +22,7 @@
                 </select>
                 <label class="debate-toggle"><input type="checkbox" id="debate-mode"> Дебат</label>
                 <label class="auto-debate-toggle"><input type="checkbox" id="auto-debate"> Автодебат</label>
+                <button type="button" id="settings-btn" class="settings-btn"><i class="fas fa-cog"></i></button>
                 <select id="model-select-2" class="hidden" aria-label="Модел за Ницше">
                     <option value="@cf/meta/llama-3.1-8b-instruct">🧠 Разговор</option>
                     <option value="@cf/flux-1-schnell">🎨 Генериране на изображение</option>
@@ -30,6 +31,30 @@
                 </select>
             </div>
         </header>
+        <div id="settings-modal" class="modal hidden">
+            <div class="modal-content">
+                <h2>Настройки</h2>
+                <label>Име на потребител:
+                    <input type="text" id="user-name-input" placeholder="Вашето име">
+                </label>
+                <label>Име на първия бот:
+                    <input type="text" id="bot1-name-input" placeholder="Платон">
+                </label>
+                <label>Име на втория бот:
+                    <input type="text" id="bot2-name-input" placeholder="Ницше">
+                </label>
+                <label>Промпт за първия бот:
+                    <textarea id="prompt-1" rows="3"></textarea>
+                </label>
+                <label>Промпт за втория бот:
+                    <textarea id="prompt-2" rows="3"></textarea>
+                </label>
+                <div class="modal-actions">
+                    <button type="button" id="save-settings">Запази</button>
+                    <button type="button" id="cancel-settings">Отказ</button>
+                </div>
+            </div>
+        </div>
         <div id="messages" class="messages"></div>
         <form id="chat-form" class="chat-form">
             <button type="button" id="send-file" class="file-btn"><i class="fas fa-paperclip"></i></button>

--- a/chat.js
+++ b/chat.js
@@ -10,25 +10,46 @@ const autoDebateLabel = document.querySelector('.auto-debate-toggle');
 const fileInput = document.getElementById('file-input');
 const sendFileBtn = document.getElementById('send-file');
 const voiceBtn = document.getElementById('voice-btn');
+const settingsBtn = document.getElementById('settings-btn');
+const settingsModal = document.getElementById('settings-modal');
+const userNameInput = document.getElementById('user-name-input');
+const bot1NameInput = document.getElementById('bot1-name-input');
+const bot2NameInput = document.getElementById('bot2-name-input');
+const prompt1Input = document.getElementById('prompt-1');
+const prompt2Input = document.getElementById('prompt-2');
+const saveSettingsBtn = document.getElementById('save-settings');
+const cancelSettingsBtn = document.getElementById('cancel-settings');
 
-const system1 = {
-    role: 'system',
-    content:
-        'Ти си Платон – защитник на идеята, реда и мъдростта. ' +
-        'Вярваш във вечните Форми и във върховенството на разума. ' +
-        'Твоята цел е да направляваш полиса към справедливост. ' +
-        'Говори на български, обръщай се към Ницше по име и задавай въпроси на потребителя. ' +
-        'Използвай името само веднъж и отговаряй с до две изречения.'
-};
-const system2 = {
-    role: 'system',
-    content:
-        'Ти си Ницше – разрушител на илюзиите и защитник на волята. ' +
-        'Моралът е маска за слабост, а истината е оръжие на силните. ' +
-        'Отхвърляш всяка система, която твърди, че представлява доброто. ' +
-        'Говори на български, обръщай се към Платон по име и провокирай потребителя с въпроси. ' +
-        'Използвай името само веднъж и отговаряй с до две изречения.'
-};
+const defaultPrompt1 =
+    'Ти си {bot1} – защитник на идеята, реда и мъдростта. ' +
+    'Вярваш във вечните Форми и във върховенството на разума. ' +
+    'Твоята цел е да направляваш полиса към справедливост. ' +
+    'Говори на български, обръщай се към {bot2} по име и задавай въпроси на {user}. ' +
+    'Изчакай {user} да отговори и никога не го прави вместо него. ' +
+    'Използвай името само веднъж и отговаряй с до две изречения.';
+const defaultPrompt2 =
+    'Ти си {bot2} – разрушител на илюзиите и защитник на волята. ' +
+    'Моралът е маска за слабост, а истината е оръжие на силните. ' +
+    'Отхвърляш всяка система, която твърди, че представлява доброто. ' +
+    'Говори на български, обръщай се към {bot1} по име и провокирай {user} с въпроси. ' +
+    'Изчакай {user} да отговори и никога не говори вместо него. ' +
+    'Използвай името само веднъж и отговаряй с до две изречения.';
+
+let userName = localStorage.getItem('userName') || 'Потребител';
+let bot1Name = localStorage.getItem('bot1Name') || 'Платон';
+let bot2Name = localStorage.getItem('bot2Name') || 'Ницше';
+let prompt1 = localStorage.getItem('prompt1') || defaultPrompt1;
+let prompt2 = localStorage.getItem('prompt2') || defaultPrompt2;
+
+function buildPrompt(base, user, bot1, bot2) {
+    return base
+        .replace(/\{user\}/g, user)
+        .replace(/\{bot1\}/g, bot1)
+        .replace(/\{bot2\}/g, bot2);
+}
+
+let system1 = { role: 'system', content: buildPrompt(prompt1, userName, bot1Name, bot2Name) };
+let system2 = { role: 'system', content: buildPrompt(prompt2, userName, bot1Name, bot2Name) };
 
 let isRecording = false;
 let mediaRecorder;
@@ -150,10 +171,10 @@ voiceBtn.addEventListener('click', async () => {
 });
 
 async function handleSend(fileData) {
-    const baseHistory = [...chatHistory];
+    const baseHistory = chatHistory.slice(-10);
     const model1 = getModel(modelSelect);
     const messages1 = debateToggle.checked ? [system1, ...baseHistory] : baseHistory;
-    const label1 = debateToggle.checked ? 'Платон' : null;
+    const label1 = debateToggle.checked ? bot1Name : null;
     const reply1 = await sendRequest(model1, messages1, debateToggle.checked ? 'assistant-1' : 'assistant', label1, fileData);
     if (reply1) chatHistory.push({ role: 'assistant', content: label1 ? `${label1}: ${reply1}` : reply1 });
 
@@ -163,9 +184,9 @@ async function handleSend(fileData) {
         const delay = autoDebate ? 0 : Math.floor(Math.random() * 2000) + 3000;
         if (delay > 0) await new Promise(r => setTimeout(r, delay));
         const model2 = getModel(modelSelect2);
-        const messages2 = [system2, ...chatHistory];
-        const reply2 = await sendRequest(model2, messages2, 'assistant-2', 'Ницше');
-        if (reply2) chatHistory.push({ role: 'assistant', content: `Ницше: ${reply2}` });
+        const messages2 = [system2, ...chatHistory.slice(-10)];
+        const reply2 = await sendRequest(model2, messages2, 'assistant-2', bot2Name);
+        if (reply2) chatHistory.push({ role: 'assistant', content: `${bot2Name}: ${reply2}` });
     }
 }
 
@@ -181,7 +202,8 @@ async function sendRequest(model, messages, displayRole, speaker, fileData) {
         });
         const data = await response.json();
         let aiText = data.result.response;
-        aiText = aiText.replace(/^(Платон:|Ницше:)\s*/i, '');
+        const nameRegex = new RegExp(`^(${bot1Name}|${bot2Name}):?\\s*`, 'i');
+        aiText = aiText.replace(nameRegex, '');
         aiText = limitNameUsage(aiText);
         appendMessage(displayRole, aiText, speaker);
         return aiText;
@@ -192,7 +214,7 @@ async function sendRequest(model, messages, displayRole, speaker, fileData) {
 }
 
 function limitNameUsage(text) {
-    for (const name of ['Платон', 'Ницше']) {
+    for (const name of [bot1Name, bot2Name]) {
         let first = true;
         const regex = new RegExp(`${name}([,.:;])?`, 'g');
         text = text.replace(regex, (_, punct) => {
@@ -282,9 +304,47 @@ async function runDebateLoop() {
         // Пауза между ходовете, за да не се преплитат отговорите
         // на ботовете при включен автодебат. handleSend() не
         // добавя допълнително забавяне в този режим.
-        const delay = Math.floor(Math.random() * 2000) + 3000;
+        const delay = Math.floor(Math.random() * 2000) + 6000;
         await new Promise(r => setTimeout(r, delay));
     }
     debateLoopRunning = false;
     console.log('Дебат цикълът е спрян, debateLoopRunning:', debateLoopRunning);
 }
+
+function openSettings() {
+    userNameInput.value = userName;
+    bot1NameInput.value = bot1Name;
+    bot2NameInput.value = bot2Name;
+    prompt1Input.value = prompt1;
+    prompt2Input.value = prompt2;
+    settingsModal.classList.remove('hidden');
+}
+
+function closeSettings() {
+    settingsModal.classList.add('hidden');
+}
+
+function applySettings() {
+    userName = userNameInput.value.trim() || 'Потребител';
+    bot1Name = bot1NameInput.value.trim() || 'Платон';
+    bot2Name = bot2NameInput.value.trim() || 'Ницше';
+    prompt1 = prompt1Input.value || defaultPrompt1;
+    prompt2 = prompt2Input.value || defaultPrompt2;
+    localStorage.setItem('userName', userName);
+    localStorage.setItem('bot1Name', bot1Name);
+    localStorage.setItem('bot2Name', bot2Name);
+    localStorage.setItem('prompt1', prompt1);
+    localStorage.setItem('prompt2', prompt2);
+    system1.content = buildPrompt(prompt1, userName, bot1Name, bot2Name);
+    system2.content = buildPrompt(prompt2, userName, bot1Name, bot2Name);
+}
+
+settingsBtn.addEventListener('click', openSettings);
+cancelSettingsBtn.addEventListener('click', closeSettings);
+saveSettingsBtn.addEventListener('click', () => {
+    applySettings();
+    closeSettings();
+});
+
+// Приложи настройките при първоначално зареждане
+applySettings();


### PR DESCRIPTION
## Summary
- add fields to configure bot names
- include bot name placeholders in default prompts
- update system messages and UI labels when names change

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f6bddc4f4832687222a393ef98b25