### PR TITLE
Add modal closing functionality

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -205,7 +205,53 @@ body {
     font-size: 1rem;
   }
 
-  .chat-form button {
-    padding: 0 12px;
+.chat-form button {
+  padding: 0 12px;
   }
+}
+
+/* Settings modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #1e1e1e;
+  color: #f5f5f5;
+  padding: 20px;
+  border-radius: 8px;
+  cursor: auto;
+  position: relative;
+  max-width: 90%;
+}
+
+.close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.settings-btn {
+  background: #1e1e1e;
+  color: #f5f5f5;
+  border: 1px solid #333;
+  padding: 5px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.modal.hidden {
+  display: none;
 }

--- a/chat.html
+++ b/chat.html
@@ -28,8 +28,9 @@
                     <option value="@cf/llama-3.2-11b-vision-instruct">🖼 Анализ на изображение</option>
                     <option value="@cf/openai/whisper-large-v3">🔊 Разпознаване на реч</option>
                 </select>
-            </div>
-        </header>
+                <button type="button" id="settings-btn" class="settings-btn"><i class="fas fa-cog"></i></button>
+                </div>
+            </header>
         <div id="messages" class="messages"></div>
         <form id="chat-form" class="chat-form">
             <button type="button" id="send-file" class="file-btn"><i class="fas fa-paperclip"></i></button>
@@ -39,6 +40,13 @@
             <button type="submit" class="send-btn"><i class="fas fa-paper-plane"></i></button>
         </form>
     </div>
-    <script src="chat.js"></script>
+        <div id="settings-modal" class="modal hidden">
+            <div class="modal-content">
+                <button id="close-settings" class="close-btn" aria-label="Затвори">&times;</button>
+                <h2>Настройки</h2>
+                <!-- Съдържанието на модала ще бъде добавено при нужда -->
+            </div>
+        </div>
+        <script src="chat.js"></script>
 </body>
 </html>

--- a/chat.js
+++ b/chat.js
@@ -10,6 +10,10 @@ const autoDebateLabel = document.querySelector('.auto-debate-toggle');
 const fileInput = document.getElementById('file-input');
 const sendFileBtn = document.getElementById('send-file');
 const voiceBtn = document.getElementById('voice-btn');
+const settingsBtn = document.getElementById('settings-btn');
+const settingsModal = document.getElementById('settings-modal');
+const modalContent = settingsModal ? settingsModal.querySelector('.modal-content') : null;
+const closeSettingsBtn = document.getElementById('close-settings');
 
 const system1 = {
     role: 'system',
@@ -287,4 +291,29 @@ async function runDebateLoop() {
     }
     debateLoopRunning = false;
     console.log('Дебат цикълът е спрян, debateLoopRunning:', debateLoopRunning);
+}
+
+// Настройки - отваряне и затваряне на модала
+if (settingsBtn && settingsModal) {
+    settingsBtn.addEventListener('click', () => {
+        settingsModal.classList.remove('hidden');
+    });
+
+    if (closeSettingsBtn) {
+        closeSettingsBtn.addEventListener('click', () => {
+            settingsModal.classList.add('hidden');
+        });
+    }
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !settingsModal.classList.contains('hidden')) {
+            settingsModal.classList.add('hidden');
+        }
+    });
+
+    settingsModal.addEventListener('click', (e) => {
+        if (e.target === settingsModal) {
+            settingsModal.classList.add('hidden');
+        }
+    });
 }


### PR DESCRIPTION
## Summary
- add settings modal markup and open button in chat page
- update chat.js to handle opening, Escape key closing, and overlay click closing
- style modal and open button in chat.css

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f70a6574483269977a3c4d9e68702