### PR TITLE
Add settings modal for debate bots

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -178,6 +178,68 @@ body {
   to { opacity: 1; transform: translateY(0); }
 }
 
+.settings-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+.settings-btn:hover {
+  color: #0b73ff;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #1e1e1e;
+  padding: 20px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+}
+
+.modal-content h2 {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.modal-content label {
+  display: block;
+  margin-bottom: 10px;
+}
+
+.modal-content input,
+.modal-content textarea {
+  width: 100%;
+  background: #2e2e2e;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 5px;
+  border-radius: 4px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
 @media (max-width: 600px) {
   .chat-container {
     width: 100%;

--- a/chat.html
+++ b/chat.html
@@ -22,6 +22,7 @@
                 </select>
                 <label class="debate-toggle"><input type="checkbox" id="debate-mode"> Дебат</label>
                 <label class="auto-debate-toggle"><input type="checkbox" id="auto-debate"> Автодебат</label>
+                <button type="button" id="settings-btn" class="settings-btn"><i class="fas fa-cog"></i></button>
                 <select id="model-select-2" class="hidden" aria-label="Модел за Ницше">
                     <option value="@cf/meta/llama-3.1-8b-instruct">🧠 Разговор</option>
                     <option value="@cf/flux-1-schnell">🎨 Генериране на изображение</option>
@@ -30,6 +31,30 @@
                 </select>
             </div>
         </header>
+        <div id="settings-modal" class="modal hidden">
+            <div class="modal-content">
+                <h2>Настройки</h2>
+                <label>Име на потребител:
+                    <input type="text" id="user-name-input" placeholder="Вашето име">
+                </label>
+                <label>Име на първия бот:
+                    <input type="text" id="bot1-name-input" placeholder="Платон">
+                </label>
+                <label>Име на втория бот:
+                    <input type="text" id="bot2-name-input" placeholder="Ницше">
+                </label>
+                <label>Промпт за първия бот:
+                    <textarea id="prompt-1" rows="3"></textarea>
+                </label>
+                <label>Промпт за втория бот:
+                    <textarea id="prompt-2" rows="3"></textarea>
+                </label>
+                <div class="modal-actions">
+                    <button type="button" id="save-settings">Запази</button>
+                    <button type="button" id="cancel-settings">Отказ</button>
+                </div>
+            </div>
+        </div>
         <div id="messages" class="messages"></div>
         <form id="chat-form" class="chat-form">
             <button type="button" id="send-file" class="file-btn"><i class="fas fa-paperclip"></i></button>


### PR DESCRIPTION
## Summary
- add modal UI to set user name and prompts
- style settings panel in chat.css
- support dynamic prompts and bot names in chat.js
- limit debate history to 10 messages and adjust auto debate delay

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684f760f70e88326bbcc71f1bffbcbe2