### PR TITLE
Improve chat design and add pause control

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -13,7 +13,7 @@ body {
 .chat-container {
   display: flex;
   flex-direction: column;
-  background: #1e1e1e;
+  background: #21242c;
   width: 100%;
   max-width: 700px;
   height: 90vh;
@@ -23,7 +23,7 @@ body {
 }
 
 .chat-header {
-  background: linear-gradient(135deg, #0044cc, #0058f5);
+  background: linear-gradient(135deg, #006eff, #00bfff);
   padding: 10px 15px;
   border-bottom: 1px solid #333;
   display: flex;
@@ -81,6 +81,24 @@ body {
   font-weight: bold;
 }
 
+.pause-btn {
+  background: #ff9800;
+  border: none;
+  color: #fff;
+  padding: 5px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.pause-btn:hover {
+  background: #ffad33;
+}
+
+.pause-btn.hidden {
+  display: none;
+}
+
 .hidden {
   display: none;
 }
@@ -103,7 +121,7 @@ body {
 
 .message.user {
   align-self: flex-end;
-  background: linear-gradient(135deg, #0058f5, #0b73ff);
+  background: linear-gradient(135deg, #006eff, #00bfff);
   color: #fff;
   border-bottom-right-radius: 0;
 }
@@ -135,7 +153,7 @@ body {
 }
 
 .chat-form {
-  background: #242424;
+  background: #262a33;
   padding: 10px;
   display: flex;
   gap: 8px;
@@ -152,7 +170,7 @@ body {
 }
 
 .chat-form button {
-  background: #0058f5;
+  background: #006eff;
   border: none;
   color: #fff;
   padding: 10px 15px;
@@ -164,7 +182,7 @@ body {
 }
 
 .chat-form button:hover {
-  background: #0b73ff;
+  background: #00bfff;
 }
 
 .voice-btn {
@@ -226,6 +244,7 @@ body {
   background: #1e1e1e;
   padding: 20px;
   border-radius: 8px;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
   width: 90%;
   max-width: 400px;
   max-height: 90vh;

--- a/chat.html
+++ b/chat.html
@@ -30,6 +30,7 @@
                 <p id="model-desc-1" class="model-description"></p>
                 <label class="debate-toggle"><input type="checkbox" id="debate-mode"> Дебат</label>
                 <label class="auto-debate-toggle"><input type="checkbox" id="auto-debate"> Автодебат</label>
+                <button type="button" id="pause-btn" class="pause-btn hidden">Пауза</button>
                 <button type="button" id="settings-btn" class="settings-btn"><i class="fas fa-cog"></i></button>
                 <select id="model-select-2" class="hidden" aria-label="Модел за Ницше">
                     <option data-desc="Стандартен модел за разговор" value="@cf/meta/llama-3.1-8b-instruct">🧠 Разговор</option>

--- a/chat.js
+++ b/chat.js
@@ -9,6 +9,7 @@ const modelDesc2 = document.getElementById('model-desc-2');
 const debateToggle = document.getElementById('debate-mode');
 const autoDebateToggle = document.getElementById('auto-debate');
 const autoDebateLabel = document.querySelector('.auto-debate-toggle');
+const pauseBtn = document.getElementById('pause-btn');
 const fileInput = document.getElementById('file-input');
 const sendFileBtn = document.getElementById('send-file');
 const voiceBtn = document.getElementById('voice-btn');
@@ -134,6 +135,7 @@ let audioChunks = [];
 voiceBtn.style.display = modelSelect.value === 'voice-chat' ? 'block' : 'none';
 modelSelect2.classList.toggle('hidden', !debateToggle.checked);
 let autoDebate = false;
+let isPaused = false;
 let debateLoopRunning = false;
 
 function escapeRegExp(str) {
@@ -150,6 +152,9 @@ const chatHistory = [];
 input.addEventListener('input', () => {
     if (input.value.trim() && autoDebate) {
         autoDebate = false;
+        isPaused = false;
+        pauseBtn.classList.add('hidden');
+        pauseBtn.textContent = 'Пауза';
         autoDebateToggle.checked = false;
         autoDebateLabel.classList.remove('running');
         console.log('Автодебатът е паузиран заради въвеждане от потребителя.');
@@ -163,6 +168,9 @@ form.addEventListener('submit', async (e) => {
 
     if (userText.toLowerCase() === 'стоп' || userText.toLowerCase() === 'stop') {
         autoDebate = false;
+        isPaused = false;
+        pauseBtn.classList.add('hidden');
+        pauseBtn.textContent = 'Пауза';
         autoDebateToggle.checked = false;
         autoDebateLabel.classList.remove('running');
         appendMessage('assistant', 'Автодебатът е спрян.');
@@ -225,8 +233,24 @@ debateToggle.addEventListener('change', () => {
 
 autoDebateToggle.addEventListener('change', () => {
     autoDebate = autoDebateToggle.checked;
+    isPaused = false;
+    pauseBtn.textContent = 'Пауза';
+    pauseBtn.classList.toggle('hidden', !autoDebate);
     autoDebateLabel.classList.toggle('running', autoDebate);
     if (autoDebate) {
+        runDebateLoop();
+    }
+});
+
+pauseBtn.addEventListener('click', () => {
+    if (!isPaused) {
+        isPaused = true;
+        pauseBtn.textContent = 'Продължи';
+        autoDebateLabel.classList.remove('running');
+    } else {
+        isPaused = false;
+        pauseBtn.textContent = 'Пауза';
+        autoDebateLabel.classList.add('running');
         runDebateLoop();
     }
 });
@@ -394,7 +418,7 @@ async function transcribeAudio(blob) {
 async function runDebateLoop() {
     if (debateLoopRunning) return;
     debateLoopRunning = true;
-    while (autoDebate) {
+    while (autoDebate && !isPaused) {
         console.log('Започва итерация на дебат цикъла');
         try {
             await handleSend();


### PR DESCRIPTION
## Summary
- add pause button for auto debate
- tweak runDebateLoop logic to support pause
- refresh color scheme and modal styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850af4d784c8326a0244b3d3825581c