### PR TITLE
Добавен toast за запазване на настройки

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -330,3 +330,22 @@ body {
   }
 }
 
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(51, 51, 51, 0.95);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 4px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.5s;
+  z-index: 1000;
+}
+
+.toast.show {
+  opacity: 1;
+}
+

--- a/chat.js
+++ b/chat.js
@@ -441,6 +441,18 @@ function clearChat() {
     chatHistory.length = 0;
 }
 
+function showToast(message) {
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    toast.textContent = message;
+    document.body.appendChild(toast);
+    requestAnimationFrame(() => toast.classList.add('show'));
+    setTimeout(() => {
+        toast.classList.remove('show');
+        setTimeout(() => toast.remove(), 500);
+    }, 2000);
+}
+
 function openSettings() {
     userNameInput.value = userName;
     bot1NameInput.value = bot1Name;
@@ -495,6 +507,7 @@ function applySettings() {
     system1.content = buildPrompt((commonPrompt ? commonPrompt + '\n' : '') + prompt1, userName, bot1Name, bot2Name, humorLevel, sarcasmLevel, aggressionLevel);
     system2.content = buildPrompt((commonPrompt ? commonPrompt + '\n' : '') + prompt2, userName, bot1Name, bot2Name, humorLevel, sarcasmLevel, aggressionLevel);
     saveStoredSettings();
+    showToast('Настройките са запазени');
 }
 
 settingsBtn.addEventListener('click', openSettings);


### PR DESCRIPTION
## Summary
- добавена нова функция `showToast` в `chat.js`
- toast съобщение при запис на настройките
- нов CSS клас `.toast` в `chat.css` за позициониране и плавно скриване

## Testing
- `npm test` *(очакван неуспех: липсва `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6850b25998cc8326a06c5cf3bd9efc79