### PR TITLE
Improve controls on small screens

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -330,3 +330,18 @@ body {
   }
 }
 
+@media (max-width: 400px) {
+  .controls {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .pause-btn {
+    padding: 8px 14px;
+  }
+
+  .settings-btn {
+    font-size: 1.3rem;
+  }
+}
+

--- a/chat.js
+++ b/chat.js
@@ -134,6 +134,7 @@ let mediaRecorder;
 let audioChunks = [];
 voiceBtn.style.display = modelSelect.value === 'voice-chat' ? 'block' : 'none';
 modelSelect2.classList.toggle('hidden', !debateToggle.checked);
+modelDesc2.classList.toggle('hidden', !debateToggle.checked);
 let autoDebate = false;
 let isPaused = false;
 let debateLoopRunning = false;


### PR DESCRIPTION
## Summary
- tweak `.controls` layout for screens under 400px
- enlarge pause and settings controls on narrow displays
- hide second model select when debate mode is off

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850b25e1a5483268cd2894a565398e2