### PR TITLE
Add theme switcher to chat page

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -1,13 +1,25 @@
+:root {
+  --bg-light: #fdf7f0;
+  --text-light: #3b2b20;
+  --bg-dark: #121212;
+  --text-dark: #f5f5f5;
+}
+
 body {
   margin: 0;
   padding: 0;
   font-family: 'Poppins', sans-serif;
-  background: #121212;
-  color: #f5f5f5;
+  background: var(--bg-light);
+  color: var(--text-light);
   display: flex;
   justify-content: center;
   align-items: center;
   height: 100vh;
+}
+
+body.dark-theme {
+  background: var(--bg-dark);
+  color: var(--text-dark);
 }
 
 .chat-container {

--- a/chat.html
+++ b/chat.html
@@ -32,6 +32,9 @@
                 <label class="auto-debate-toggle"><input type="checkbox" id="auto-debate"> Автодебат</label>
                 <button type="button" id="pause-btn" class="pause-btn hidden">Пауза</button>
                 <button type="button" id="settings-btn" class="settings-btn"><i class="fas fa-cog"></i></button>
+                <button class="theme-toggle" aria-label="Toggle theme">
+                    <i class="fas fa-moon"></i>
+                </button>
                 <select id="model-select-2" class="hidden" aria-label="Модел за Ницше">
                     <option data-desc="Стандартен модел за разговор" value="@cf/meta/llama-3.1-8b-instruct">🧠 Разговор</option>
                     <option data-desc="Универсален чат модел" value="@cf/qwen/qwen1.5-7b-chat-awq">🤖 Qwen 1.5-7B</option>

--- a/chat.js
+++ b/chat.js
@@ -13,6 +13,9 @@ const pauseBtn = document.getElementById('pause-btn');
 const fileInput = document.getElementById('file-input');
 const sendFileBtn = document.getElementById('send-file');
 const voiceBtn = document.getElementById('voice-btn');
+const themeToggle = document.querySelector('.theme-toggle');
+const body = document.body;
+const themeIcon = themeToggle.querySelector('i');
 const settingsBtn = document.getElementById('settings-btn');
 const settingsModal = document.getElementById('settings-modal');
 const userNameInput = document.getElementById('user-name-input');
@@ -31,6 +34,33 @@ const aggressionInput = document.getElementById('aggression-level');
 const delayInput = document.getElementById('delay-level');
 const saveSettingsBtn = document.getElementById('save-settings');
 const cancelSettingsBtn = document.getElementById('cancel-settings');
+
+// Настройки на темата
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme) {
+    body.classList.add(savedTheme);
+    updateThemeIcon();
+}
+
+themeToggle.addEventListener('click', () => {
+    body.classList.toggle('dark-theme');
+    if (body.classList.contains('dark-theme')) {
+        localStorage.setItem('theme', 'dark-theme');
+    } else {
+        localStorage.removeItem('theme');
+    }
+    updateThemeIcon();
+});
+
+function updateThemeIcon() {
+    if (body.classList.contains('dark-theme')) {
+        themeIcon.classList.remove('fa-moon');
+        themeIcon.classList.add('fa-sun');
+    } else {
+        themeIcon.classList.remove('fa-sun');
+        themeIcon.classList.add('fa-moon');
+    }
+}
 const defaultPrompt1 =
     'Ти си {bot1} – защитник на идеята, реда и мъдростта. ' +
     'Вярваш във вечните Форми и във върховенството на разума. ' +


### PR DESCRIPTION
## Summary
- add CSS variables for light and dark colors in `chat.css`
- include a theme toggle button in `chat.html`
- manage theme state and icon in `chat.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850b26478308326b19cbef2b9a610f8