### PR TITLE
Add slider value displays and live update

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -274,6 +274,11 @@ body {
   margin-bottom: 10px;
 }
 
+.modal-content .value {
+  margin-left: 6px;
+  font-weight: 600;
+}
+
 .modal-content input,
 .modal-content textarea {
   width: 100%;

--- a/chat.html
+++ b/chat.html
@@ -71,27 +71,35 @@
                 </label>
                 <label>Дължина на отговора (бот 1):
                     <input type="range" id="length-1" min="20" max="400" value="60">
+                    <span class="value">60</span>
                 </label>
                 <label>Температура (бот 1):
                     <input type="range" id="temp-1" min="0" max="1.5" step="0.1" value="0.7">
+                    <span class="value">0.7</span>
                 </label>
                 <label>Дължина на отговора (бот 2):
                     <input type="range" id="length-2" min="20" max="400" value="60">
+                    <span class="value">60</span>
                 </label>
                 <label>Температура (бот 2):
                     <input type="range" id="temp-2" min="0" max="1.5" step="0.1" value="0.7">
+                    <span class="value">0.7</span>
                 </label>
                 <label>Хумор:
                     <input type="range" id="humor-level" min="0" max="10" value="0">
+                    <span class="value">0</span>
                 </label>
                 <label>Сарказъм:
                     <input type="range" id="sarcasm-level" min="0" max="10" value="0">
+                    <span class="value">0</span>
                 </label>
                 <label>Агресия:
                     <input type="range" id="aggression-level" min="0" max="10" value="0">
+                    <span class="value">0</span>
                 </label>
                 <label>Изчакване (сек.):
                     <input type="range" id="delay-level" min="0" max="10" value="3">
+                    <span class="value">3</span>
                 </label>
                 <div class="modal-actions">
                     <button type="button" id="save-settings">Запази</button>

--- a/chat.js
+++ b/chat.js
@@ -29,6 +29,15 @@ const humorInput = document.getElementById('humor-level');
 const sarcasmInput = document.getElementById('sarcasm-level');
 const aggressionInput = document.getElementById('aggression-level');
 const delayInput = document.getElementById('delay-level');
+
+const length1Value = length1Input.nextElementSibling;
+const temp1Value = temp1Input.nextElementSibling;
+const length2Value = length2Input.nextElementSibling;
+const temp2Value = temp2Input.nextElementSibling;
+const humorValue = humorInput.nextElementSibling;
+const sarcasmValue = sarcasmInput.nextElementSibling;
+const aggressionValue = aggressionInput.nextElementSibling;
+const delayValue = delayInput.nextElementSibling;
 const saveSettingsBtn = document.getElementById('save-settings');
 const cancelSettingsBtn = document.getElementById('cancel-settings');
 const defaultPrompt1 =
@@ -124,6 +133,24 @@ function buildPrompt(base, user, bot1, bot2, humor, sarcasm, aggression) {
 
 let system1 = { role: 'system', content: buildPrompt((commonPrompt ? commonPrompt + '\n' : '') + prompt1, userName, bot1Name, bot2Name, humorLevel, sarcasmLevel, aggressionLevel) };
 let system2 = { role: 'system', content: buildPrompt((commonPrompt ? commonPrompt + '\n' : '') + prompt2, userName, bot1Name, bot2Name, humorLevel, sarcasmLevel, aggressionLevel) };
+
+function updateSystemPrompts() {
+    system1.content = buildPrompt((commonPrompt ? commonPrompt + '\n' : '') + prompt1,
+        userName, bot1Name, bot2Name, humorLevel, sarcasmLevel, aggressionLevel);
+    system2.content = buildPrompt((commonPrompt ? commonPrompt + '\n' : '') + prompt2,
+        userName, bot1Name, bot2Name, humorLevel, sarcasmLevel, aggressionLevel);
+}
+
+function updateSliderDisplays() {
+    length1Value.textContent = length1Input.value;
+    temp1Value.textContent = temp1Input.value;
+    length2Value.textContent = length2Input.value;
+    temp2Value.textContent = temp2Input.value;
+    humorValue.textContent = humorInput.value;
+    sarcasmValue.textContent = sarcasmInput.value;
+    aggressionValue.textContent = aggressionInput.value;
+    delayValue.textContent = delayInput.value;
+}
 
 function participantNames() {
     return [bot1Name, bot2Name];
@@ -456,6 +483,7 @@ function openSettings() {
     sarcasmInput.value = sarcasmLevel;
     aggressionInput.value = aggressionLevel;
     delayInput.value = delayLevel;
+    updateSliderDisplays();
     settingsModal.classList.remove('hidden');
 }
 
@@ -492,8 +520,8 @@ function applySettings() {
     sarcasmLevel = parseInt(sarcasmInput.value);
     aggressionLevel = parseInt(aggressionInput.value);
     delayLevel = parseInt(delayInput.value);
-    system1.content = buildPrompt((commonPrompt ? commonPrompt + '\n' : '') + prompt1, userName, bot1Name, bot2Name, humorLevel, sarcasmLevel, aggressionLevel);
-    system2.content = buildPrompt((commonPrompt ? commonPrompt + '\n' : '') + prompt2, userName, bot1Name, bot2Name, humorLevel, sarcasmLevel, aggressionLevel);
+    updateSystemPrompts();
+    updateSliderDisplays();
     saveStoredSettings();
 }
 
@@ -502,6 +530,54 @@ cancelSettingsBtn.addEventListener('click', closeSettings);
 saveSettingsBtn.addEventListener('click', () => {
     applySettings();
     closeSettings();
+});
+
+length1Input.addEventListener('input', () => {
+    length1 = parseInt(length1Input.value);
+    length1Value.textContent = length1Input.value;
+    updateSystemPrompts();
+});
+
+temp1Input.addEventListener('input', () => {
+    temp1 = parseFloat(temp1Input.value);
+    temp1Value.textContent = temp1Input.value;
+    updateSystemPrompts();
+});
+
+length2Input.addEventListener('input', () => {
+    length2 = parseInt(length2Input.value);
+    length2Value.textContent = length2Input.value;
+    updateSystemPrompts();
+});
+
+temp2Input.addEventListener('input', () => {
+    temp2 = parseFloat(temp2Input.value);
+    temp2Value.textContent = temp2Input.value;
+    updateSystemPrompts();
+});
+
+humorInput.addEventListener('input', () => {
+    humorLevel = parseInt(humorInput.value);
+    humorValue.textContent = humorInput.value;
+    updateSystemPrompts();
+});
+
+sarcasmInput.addEventListener('input', () => {
+    sarcasmLevel = parseInt(sarcasmInput.value);
+    sarcasmValue.textContent = sarcasmInput.value;
+    updateSystemPrompts();
+});
+
+aggressionInput.addEventListener('input', () => {
+    aggressionLevel = parseInt(aggressionInput.value);
+    aggressionValue.textContent = aggressionInput.value;
+    updateSystemPrompts();
+});
+
+delayInput.addEventListener('input', () => {
+    delayLevel = parseInt(delayInput.value);
+    delayValue.textContent = delayInput.value;
+    updateSystemPrompts();
 });
 clearChatBtn.addEventListener('click', () => {
     if (confirm('Да изчистя ли историята на чата?')) {
@@ -527,6 +603,7 @@ clearChatBtn.addEventListener('click', () => {
     aggressionInput.value = aggressionLevel;
     delayInput.value = delayLevel;
     applySettings();
+    updateSliderDisplays();
     updateDescription(modelSelect, modelDesc1);
     updateDescription(modelSelect2, modelDesc2);
 })();


### PR DESCRIPTION
## Summary
- show numeric value next to every slider in settings
- update slider values and system prompts immediately when moving a range input
- style `.value` elements inside the modal

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850b2600a7c8326abffd5f2d9e5b5af