### PR TITLE
Подобрена мобилна поддръжка на чата

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -366,3 +366,18 @@ body.dark-theme {
   opacity: 1;
 }
 
+@media (max-width: 400px) {
+  .controls {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .pause-btn {
+    font-size: 1rem;
+    padding: 8px 12px;
+  }
+  .settings-btn {
+    font-size: 1.3rem;
+  }
+}
+

--- a/chat.js
+++ b/chat.js
@@ -191,6 +191,7 @@ let mediaRecorder;
 let audioChunks = [];
 voiceBtn.style.display = modelSelect.value === 'voice-chat' ? 'block' : 'none';
 modelSelect2.classList.toggle('hidden', !debateToggle.checked);
+modelDesc2.classList.toggle('hidden', !debateToggle.checked);
 let autoDebate = false;
 let isPaused = false;
 let debateLoopRunning = false;


### PR DESCRIPTION
## Обобщение
- добавено `@media (max-width: 400px)` в *chat.css*
- при малки екрани `.controls` се подреждат вертикално с по-голямо разстояние
- увеличен размер на бутона за пауза и иконата за настройки
- при зареждане на страницата се скрива и описанието на втория модел

## Тестване
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6850b4a5fa1c8326b309ed80bdb4b959