### PR TITLE
Добавяне на икони при свито меню

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -44,6 +44,24 @@ body {
   align-items: center;
   gap: 8px;
 }
+.icon-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+.icon-btn:hover {
+  color: #0b73ff;
+}
+
+.collapsed-only {
+  display: none;
+}
+
+.chat-header.collapsed .collapsed-only {
+  display: inline-flex;
+}
 .model-description {
   font-size: 0.8rem;
   margin: 2px 0 8px;

--- a/chat.html
+++ b/chat.html
@@ -14,8 +14,11 @@
             <h1><i class="fas fa-comments"></i> Into AI Chat</h1>
             <div class="header-buttons">
                 <button id="menu-toggle" class="menu-toggle" aria-label="Меню" aria-expanded="true"><i class="fas fa-bars"></i></button>
-                <button type="button" id="clear-chat" class="clear-btn"><i class="fas fa-trash"></i></button>
-                <button type="button" id="pause-btn" class="pause-btn hidden">Пауза</button>
+                <button id="debate-icon" class="icon-btn collapsed-only" aria-label="Дебат"><i class="fas fa-users"></i></button>
+                <button id="auto-debate-icon" class="icon-btn collapsed-only" aria-label="Автодебат"><i class="fas fa-robot"></i></button>
+                <button id="settings-icon" class="icon-btn collapsed-only" aria-label="Настройки"><i class="fas fa-cog"></i></button>
+                <button type="button" id="pause-icon" class="icon-btn collapsed-only hidden" aria-label="Пауза"><i class="fas fa-pause"></i></button>
+                <button type="button" id="clear-chat" class="clear-btn icon-btn" aria-label="Нов чат"><i class="fas fa-trash"></i></button>
             </div>
             <div class="controls">
                 <select id="model-select">

--- a/chat.js
+++ b/chat.js
@@ -31,6 +31,10 @@ const humorInput = document.getElementById('humor-level');
 const sarcasmInput = document.getElementById('sarcasm-level');
 const aggressionInput = document.getElementById('aggression-level');
 const delayInput = document.getElementById('delay-level');
+const debateIcon = document.getElementById("debate-icon");
+const autoDebateIcon = document.getElementById("auto-debate-icon");
+const settingsIcon = document.getElementById("settings-icon");
+const pauseIcon = document.getElementById("pause-icon");
 
 const length1Value = length1Input.nextElementSibling;
 const temp1Value = temp1Input.nextElementSibling;
@@ -191,6 +195,8 @@ input.addEventListener('input', () => {
         pauseBtn.classList.add('hidden');
         pauseBtn.textContent = 'Пауза';
         autoDebateToggle.checked = false;
+        pauseIcon.classList.add("hidden");
+        pauseIcon.querySelector("i").className = "fas fa-pause";
         autoDebateLabel.classList.remove('running');
         console.log('Автодебатът е паузиран заради въвеждане от потребителя.');
     }
@@ -207,6 +213,8 @@ form.addEventListener('submit', async (e) => {
         pauseBtn.classList.add('hidden');
         pauseBtn.textContent = 'Пауза';
         autoDebateToggle.checked = false;
+        pauseIcon.classList.add("hidden");
+        pauseIcon.querySelector("i").className = "fas fa-pause";
         autoDebateLabel.classList.remove('running');
         appendMessage('assistant', 'Автодебатът е спрян.');
         input.value = '';
@@ -271,6 +279,8 @@ autoDebateToggle.addEventListener('change', () => {
     isPaused = false;
     pauseBtn.textContent = 'Пауза';
     pauseBtn.classList.toggle('hidden', !autoDebate);
+    pauseIcon.querySelector("i").className = "fas fa-pause";
+    pauseIcon.classList.toggle("hidden", !autoDebate);
     autoDebateLabel.classList.toggle('running', autoDebate);
     if (autoDebate) {
         runDebateLoop();
@@ -282,10 +292,12 @@ pauseBtn.addEventListener('click', () => {
         isPaused = true;
         pauseBtn.textContent = 'Продължи';
         autoDebateLabel.classList.remove('running');
+        pauseIcon.querySelector("i").className = "fas fa-play";
     } else {
         isPaused = false;
         pauseBtn.textContent = 'Пауза';
         autoDebateLabel.classList.add('running');
+        pauseIcon.querySelector("i").className = "fas fa-pause";
         runDebateLoop();
     }
 });
@@ -547,6 +559,10 @@ function applySettings() {
 }
 
 settingsBtn.addEventListener('click', openSettings);
+settingsIcon.addEventListener("click", openSettings);
+debateIcon.addEventListener("click", () => debateToggle.click());
+autoDebateIcon.addEventListener("click", () => autoDebateToggle.click());
+pauseIcon.addEventListener("click", () => pauseBtn.click());
 cancelSettingsBtn.addEventListener('click', closeSettings);
 saveSettingsBtn.addEventListener('click', () => {
     applySettings();


### PR DESCRIPTION
## Summary
- показване на компактни икони за дебат, автодебат, настройки и пауза
- добавяне на стилове за икони и показване само при свито меню
- свързване на новите икони със съществуващите бутони

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6850bf60a1608326954a41ddcca44658