### PR TITLE
Add fullscreen prompt editing

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -410,6 +410,48 @@ body {
   opacity: 1;
 }
 
+.prompt-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.85);
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  z-index: 1100;
+}
+
+.prompt-overlay textarea {
+  width: 100%;
+  max-width: 800px;
+  height: 70vh;
+  background: #1e1e1e;
+  border: 1px solid #555;
+  color: #fff;
+  border-radius: 6px;
+  padding: 10px;
+  resize: vertical;
+}
+
+.prompt-overlay button {
+  margin-top: 10px;
+  background: #0b73ff;
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.prompt-overlay:not(.hidden) {
+  display: flex;
+}
+
 @media (max-width: 400px) {
   .controls {
     flex-direction: column;

--- a/chat.html
+++ b/chat.html
@@ -115,6 +115,10 @@
                 </div>
             </div>
         </div>
+        <div id="prompt-overlay" class="prompt-overlay hidden">
+            <textarea id="prompt-overlay-text"></textarea>
+            <button type="button" id="prompt-overlay-close">Готово</button>
+        </div>
         <div id="messages" class="messages"></div>
         <form id="chat-form" class="chat-form">
             <button type="button" id="send-file" class="file-btn"><i class="fas fa-paperclip"></i></button>

--- a/chat.js
+++ b/chat.js
@@ -35,6 +35,11 @@ const debateIcon = document.getElementById("debate-icon");
 const autoDebateIcon = document.getElementById("auto-debate-icon");
 const settingsIcon = document.getElementById("settings-icon");
 const pauseIcon = document.getElementById("pause-icon");
+const promptOverlay = document.getElementById('prompt-overlay');
+const promptOverlayText = document.getElementById('prompt-overlay-text');
+const promptOverlayClose = document.getElementById('prompt-overlay-close');
+
+let activePromptField = null;
 
 const length1Value = length1Input.nextElementSibling;
 const temp1Value = temp1Input.nextElementSibling;
@@ -523,6 +528,22 @@ function closeSettings() {
     settingsModal.classList.add('hidden');
 }
 
+function openPromptEditor(field) {
+    activePromptField = field;
+    promptOverlayText.value = field.value;
+    promptOverlay.classList.remove('hidden');
+    promptOverlayText.focus();
+}
+
+function closePromptEditor() {
+    if (activePromptField) {
+        activePromptField.value = promptOverlayText.value;
+        activePromptField.focus();
+        activePromptField = null;
+    }
+    promptOverlay.classList.add('hidden');
+}
+
 function applySettings() {
     userName = userNameInput.value.trim() || 'Потребител';
     bot1Name = bot1NameInput.value.trim() || 'Платон';
@@ -568,6 +589,15 @@ saveSettingsBtn.addEventListener('click', () => {
     applySettings();
     closeSettings();
 });
+promptOverlayClose.addEventListener('click', closePromptEditor);
+promptOverlayText.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+        closePromptEditor();
+    }
+});
+commonPromptInput.addEventListener('focus', () => openPromptEditor(commonPromptInput));
+prompt1Input.addEventListener('focus', () => openPromptEditor(prompt1Input));
+prompt2Input.addEventListener('focus', () => openPromptEditor(prompt2Input));
 
 menuToggle.addEventListener('click', () => {
     const collapsed = chatHeader.classList.toggle('collapsed');


### PR DESCRIPTION
## Summary
- open prompt inputs in a fullscreen overlay for easier editing
- add close button and ESC handling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850c193a1288326b6077faecd93d080