### PR TITLE
Improve collapsed menu buttons

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -54,6 +54,12 @@ body {
 .icon-btn:hover {
   color: #0b73ff;
 }
+.icon-btn.active {
+  color: #2ecc71;
+}
+.icon-btn.inactive {
+  color: #e74c3c;
+}
 
 .collapsed-only {
   display: none;
@@ -88,6 +94,12 @@ body {
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-wrap: wrap;
+}
+.controls label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .chat-header.collapsed .controls {

--- a/chat.html
+++ b/chat.html
@@ -13,12 +13,12 @@
         <header class="chat-header">
             <h1><i class="fas fa-comments"></i> Into AI Chat</h1>
             <div class="header-buttons">
-                <button id="menu-toggle" class="menu-toggle" aria-label="Меню" aria-expanded="true"><i class="fas fa-bars"></i></button>
-                <button id="debate-icon" class="icon-btn collapsed-only" aria-label="Дебат"><i class="fas fa-users"></i></button>
-                <button id="auto-debate-icon" class="icon-btn collapsed-only" aria-label="Автодебат"><i class="fas fa-robot"></i></button>
-                <button id="settings-icon" class="icon-btn collapsed-only" aria-label="Настройки"><i class="fas fa-cog"></i></button>
-                <button type="button" id="pause-icon" class="icon-btn collapsed-only hidden" aria-label="Пауза"><i class="fas fa-pause"></i></button>
-                <button type="button" id="clear-chat" class="clear-btn icon-btn" aria-label="Нов чат"><i class="fas fa-trash"></i></button>
+                <button id="menu-toggle" class="menu-toggle" aria-label="Меню" aria-expanded="true" title="Меню"><i class="fas fa-bars"></i></button>
+                <button id="debate-icon" class="icon-btn collapsed-only" aria-label="Дебат" title="Дебат"><i class="fas fa-users"></i></button>
+                <button id="auto-debate-icon" class="icon-btn collapsed-only" aria-label="Автодебат" title="Автодебат"><i class="fas fa-robot"></i></button>
+                <button id="settings-icon" class="icon-btn collapsed-only" aria-label="Настройки" title="Настройки"><i class="fas fa-cog"></i></button>
+                <button type="button" id="pause-icon" class="icon-btn collapsed-only hidden" aria-label="Пауза" title="Пауза"><i class="fas fa-pause"></i></button>
+                <button type="button" id="clear-chat" class="clear-btn icon-btn" aria-label="Нов чат" title="Нов чат"><i class="fas fa-trash"></i></button>
             </div>
             <div class="controls">
                 <select id="model-select">

--- a/chat.js
+++ b/chat.js
@@ -275,8 +275,12 @@ modelSelect2.addEventListener('change', () => {
 });
 
 debateToggle.addEventListener('change', () => {
-    modelSelect2.classList.toggle('hidden', !debateToggle.checked);
-    modelDesc2.classList.toggle('hidden', !debateToggle.checked);
+    const enabled = debateToggle.checked;
+    modelSelect2.classList.toggle('hidden', !enabled);
+    modelDesc2.classList.toggle('hidden', !enabled);
+    debateIcon.classList.toggle('active', enabled);
+    debateIcon.classList.toggle('inactive', !enabled);
+    showToast(`Дебат: ${enabled ? 'включен' : 'изключен'}`);
 });
 
 autoDebateToggle.addEventListener('change', () => {
@@ -287,6 +291,9 @@ autoDebateToggle.addEventListener('change', () => {
     pauseIcon.querySelector("i").className = "fas fa-pause";
     pauseIcon.classList.toggle("hidden", !autoDebate);
     autoDebateLabel.classList.toggle('running', autoDebate);
+    autoDebateIcon.classList.toggle('active', autoDebate);
+    autoDebateIcon.classList.toggle('inactive', !autoDebate);
+    showToast(`Автодебат: ${autoDebate ? 'включен' : 'изключен'}`);
     if (autoDebate) {
         runDebateLoop();
     }
@@ -298,12 +305,18 @@ pauseBtn.addEventListener('click', () => {
         pauseBtn.textContent = 'Продължи';
         autoDebateLabel.classList.remove('running');
         pauseIcon.querySelector("i").className = "fas fa-play";
+        pauseIcon.classList.add('inactive');
+        pauseIcon.classList.remove('active');
+        showToast('Автодебат: пауза');
     } else {
         isPaused = false;
         pauseBtn.textContent = 'Пауза';
         autoDebateLabel.classList.add('running');
         pauseIcon.querySelector("i").className = "fas fa-pause";
         runDebateLoop();
+        pauseIcon.classList.add('active');
+        pauseIcon.classList.remove('inactive');
+        showToast('Автодебат: продължи');
     }
 });
 
@@ -522,10 +535,14 @@ function openSettings() {
     delayInput.value = delayLevel;
     updateSliderDisplays();
     settingsModal.classList.remove('hidden');
+    settingsIcon.classList.add('active');
+    showToast('Отворени настройки');
 }
 
 function closeSettings() {
     settingsModal.classList.add('hidden');
+    settingsIcon.classList.remove('active');
+    showToast('Настройките затворени');
 }
 
 function openPromptEditor(field) {
@@ -604,6 +621,8 @@ menuToggle.addEventListener('click', () => {
     menuToggle.setAttribute('aria-expanded', String(!collapsed));
     menuCollapsed = collapsed;
     localStorage.setItem('menuCollapsed', collapsed);
+    menuToggle.classList.toggle('active', collapsed);
+    showToast(`Меню: ${collapsed ? 'компактно' : 'разширено'}`);
 });
 
 length1Input.addEventListener('input', () => {
@@ -656,6 +675,7 @@ delayInput.addEventListener('input', () => {
 clearChatBtn.addEventListener('click', () => {
     if (confirm('Да изчистя ли историята на чата?')) {
         clearChat();
+        showToast('Чатът е изчистен');
     }
 });
 
@@ -680,6 +700,13 @@ clearChatBtn.addEventListener('click', () => {
         chatHeader.classList.add('collapsed');
     }
     menuToggle.setAttribute('aria-expanded', String(!menuCollapsed));
+    debateIcon.classList.toggle('active', debateToggle.checked);
+    debateIcon.classList.toggle('inactive', !debateToggle.checked);
+    autoDebateIcon.classList.toggle('active', autoDebateToggle.checked);
+    autoDebateIcon.classList.toggle('inactive', !autoDebateToggle.checked);
+    menuToggle.classList.toggle('active', menuCollapsed);
+    pauseIcon.classList.toggle('active', autoDebateToggle.checked && !isPaused);
+    pauseIcon.classList.toggle('inactive', autoDebateToggle.checked && isPaused);
     applySettings();
     updateSliderDisplays();
     updateDescription(modelSelect, modelDesc1);


### PR DESCRIPTION
## Summary
- add titles to header icons for clarity
- show active state colours and wrap controls neatly
- notify user with toast messages when toggling features

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6850c39a0360832693c679f9ce891f7d