### PR TITLE
UI updates and auto-debate pause

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -27,8 +27,9 @@ body {
   padding: 10px 15px;
   border-bottom: 1px solid #333;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
+  gap: 10px;
 }
 
 .chat-header h1 {
@@ -241,7 +242,7 @@ body {
   background: #d32f2f;
 }
 
-#clear-chat {
+#restart-chat {
   background: #d32f2f;
   border: none;
   color: #fff;
@@ -249,9 +250,11 @@ body {
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.9rem;
+  margin-left: auto;
+  align-self: flex-start;
 }
 
-#clear-chat:hover {
+#restart-chat:hover {
   background: #e64a4a;
 }
 

--- a/chat.html
+++ b/chat.html
@@ -18,7 +18,6 @@
                 <button id="auto-debate-icon" class="icon-btn collapsed-only" aria-label="Автодебат" title="Автодебат"><i class="fas fa-robot"></i></button>
                 <button id="settings-icon" class="icon-btn collapsed-only" aria-label="Настройки" title="Настройки"><i class="fas fa-cog"></i></button>
                 <button type="button" id="pause-icon" class="icon-btn collapsed-only hidden" aria-label="Пауза" title="Пауза"><i class="fas fa-pause"></i></button>
-                <button type="button" id="clear-chat" class="clear-btn icon-btn" aria-label="Нов чат" title="Нов чат"><i class="fas fa-trash"></i></button>
             </div>
             <div class="controls">
                 <select id="model-select">
@@ -55,6 +54,7 @@
                 </select>
                 <p id="model-desc-2" class="model-description hidden"></p>
             </div>
+            <button type="button" id="restart-chat" class="clear-btn icon-btn" aria-label="Рестарт" title="Рестарт"><i class="fas fa-rotate-right"></i></button>
         </header>
         <div id="settings-modal" class="modal hidden">
             <div class="modal-content">

--- a/chat.js
+++ b/chat.js
@@ -189,21 +189,20 @@ function escapeRegExp(str) {
 const messagesEl = document.getElementById('messages');
 const form = document.getElementById('chat-form');
 const input = document.getElementById('user-input');
-const clearChatBtn = document.getElementById('clear-chat');
+const restartBtn = document.getElementById('restart-chat');
 
 const chatHistory = [];
 
+let pausedByInput = false;
 input.addEventListener('input', () => {
-    if (input.value.trim() && autoDebate) {
-        autoDebate = false;
-        isPaused = false;
-        pauseBtn.classList.add('hidden');
-        pauseBtn.textContent = 'Пауза';
-        autoDebateToggle.checked = false;
-        pauseIcon.classList.add("hidden");
-        pauseIcon.querySelector("i").className = "fas fa-pause";
+    if (input.value.trim() && autoDebate && !isPaused) {
+        isPaused = true;
+        pausedByInput = true;
+        pauseBtn.textContent = 'Продължи';
         autoDebateLabel.classList.remove('running');
-        console.log('Автодебатът е паузиран заради въвеждане от потребителя.');
+        pauseIcon.querySelector("i").className = "fas fa-play";
+        pauseIcon.classList.add('inactive');
+        pauseIcon.classList.remove('active');
     }
 });
 
@@ -235,6 +234,17 @@ form.addEventListener('submit', async (e) => {
         await handleSend();
     } catch (err) {
         console.error('Грешка при handleSend:', err);
+    }
+
+    if (pausedByInput && autoDebate) {
+        isPaused = false;
+        pausedByInput = false;
+        pauseBtn.textContent = 'Пауза';
+        autoDebateLabel.classList.add('running');
+        pauseIcon.querySelector("i").className = "fas fa-pause";
+        pauseIcon.classList.add('active');
+        pauseIcon.classList.remove('inactive');
+        runDebateLoop();
     }
 });
 
@@ -625,6 +635,18 @@ menuToggle.addEventListener('click', () => {
     showToast(`Меню: ${collapsed ? 'компактно' : 'разширено'}`);
 });
 
+document.addEventListener('click', (e) => {
+    if (!chatHeader.classList.contains('collapsed') &&
+        !chatHeader.contains(e.target) && e.target !== menuToggle) {
+        chatHeader.classList.add('collapsed');
+        menuToggle.setAttribute('aria-expanded', 'false');
+        menuCollapsed = true;
+        localStorage.setItem('menuCollapsed', true);
+        menuToggle.classList.add('active');
+        showToast('Меню: компактно');
+    }
+});
+
 length1Input.addEventListener('input', () => {
     length1 = parseInt(length1Input.value);
     length1Value.textContent = length1Input.value;
@@ -672,11 +694,8 @@ delayInput.addEventListener('input', () => {
     delayValue.textContent = delayInput.value;
     updateSystemPrompts();
 });
-clearChatBtn.addEventListener('click', () => {
-    if (confirm('Да изчистя ли историята на чата?')) {
-        clearChat();
-        showToast('Чатът е изчистен');
-    }
+restartBtn.addEventListener('click', () => {
+    location.reload();
 });
 
 (async () => {


### PR DESCRIPTION
## Summary
- replace "clear chat" button with restart button and move it to the far right
- pause auto debate when typing and resume after message
- close the menu when clicking outside of it

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850c6fc39e88326b46e7d6de8bdf446