### PR TITLE
Fix restart button layout

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -250,8 +250,7 @@ body {
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.9rem;
-  margin-left: auto;
-  align-self: flex-start;
+  margin-left: 0;
 }
 
 #restart-chat:hover {

--- a/chat.html
+++ b/chat.html
@@ -18,6 +18,7 @@
                 <button id="auto-debate-icon" class="icon-btn collapsed-only" aria-label="Автодебат" title="Автодебат"><i class="fas fa-robot"></i></button>
                 <button id="settings-icon" class="icon-btn collapsed-only" aria-label="Настройки" title="Настройки"><i class="fas fa-cog"></i></button>
                 <button type="button" id="pause-icon" class="icon-btn collapsed-only hidden" aria-label="Пауза" title="Пауза"><i class="fas fa-pause"></i></button>
+                <button type="button" id="restart-chat" class="clear-btn icon-btn" aria-label="Рестарт" title="Рестарт"><i class="fas fa-rotate-right"></i></button>
             </div>
             <div class="controls">
                 <select id="model-select">
@@ -54,7 +55,6 @@
                 </select>
                 <p id="model-desc-2" class="model-description hidden"></p>
             </div>
-            <button type="button" id="restart-chat" class="clear-btn icon-btn" aria-label="Рестарт" title="Рестарт"><i class="fas fa-rotate-right"></i></button>
         </header>
         <div id="settings-modal" class="modal hidden">
             <div class="modal-content">


### PR DESCRIPTION
## Summary
- keep header buttons compact by moving restart button into the same flex row
- adjust restart button CSS so it doesn't push onto a new line

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850c8bd927c8326a2b5fa8e17de2348