### PR TITLE
Подобряване на лентата с бутони в чата

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -24,12 +24,12 @@ body {
 
 .chat-header {
   background: linear-gradient(135deg, #006eff, #00bfff);
-  padding: 10px 15px;
+  padding: 6px 10px;
   border-bottom: 1px solid #333;
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
 .chat-header h1 {
@@ -43,7 +43,7 @@ body {
 .header-buttons {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 .icon-btn {
   background: none;
@@ -94,7 +94,7 @@ body {
 .controls {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 .controls label {
@@ -250,7 +250,7 @@ body {
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.9rem;
-  margin-left: 0;
+  margin-left: auto;
 }
 
 #restart-chat:hover {
@@ -373,8 +373,8 @@ body {
   }
 
   .chat-header {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
     gap: 6px;
   }
 

--- a/chat.html
+++ b/chat.html
@@ -18,7 +18,6 @@
                 <button id="auto-debate-icon" class="icon-btn collapsed-only" aria-label="Автодебат" title="Автодебат"><i class="fas fa-robot"></i></button>
                 <button id="settings-icon" class="icon-btn collapsed-only" aria-label="Настройки" title="Настройки"><i class="fas fa-cog"></i></button>
                 <button type="button" id="pause-icon" class="icon-btn collapsed-only hidden" aria-label="Пауза" title="Пауза"><i class="fas fa-pause"></i></button>
-                <button type="button" id="restart-chat" class="clear-btn icon-btn" aria-label="Рестарт" title="Рестарт"><i class="fas fa-rotate-right"></i></button>
             </div>
             <div class="controls">
                 <select id="model-select">
@@ -55,6 +54,7 @@
                 </select>
                 <p id="model-desc-2" class="model-description hidden"></p>
             </div>
+            <button type="button" id="restart-chat" class="clear-btn icon-btn" aria-label="Рестарт" title="Рестарт"><i class="fas fa-rotate-right"></i></button>
         </header>
         <div id="settings-modal" class="modal hidden">
             <div class="modal-content">


### PR DESCRIPTION
## Summary
- местим бутона за рестарт в края на заглавната лента
- намаляваме височината и разстоянията в `.chat-header`
- стесняваме разстоянията в `.header-buttons` и `.controls`
- бутонът за рестарт се фиксира вдясно чрез `margin-left: auto`
- запазваме хоризонталното подреждане при малки екрани

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850caa5b3488326ad1399c30fc5f0e3