### PR TITLE
Add saved profiles and default LLaMA 4 model

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -365,6 +365,21 @@ body {
   gap: 10px;
 }
 
+.profile-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 10px 0;
+}
+.profile-actions select {
+  flex: 1;
+  background: #1e1e1e;
+  color: #f5f5f5;
+  border: 1px solid #333;
+  padding: 5px 10px;
+  border-radius: 4px;
+}
+
 @media (max-width: 600px) {
   .chat-container {
     width: 100%;

--- a/chat.html
+++ b/chat.html
@@ -20,13 +20,13 @@
                 <button type="button" id="pause-icon" class="icon-btn collapsed-only hidden" aria-label="Пауза" title="Пауза"><i class="fas fa-pause"></i></button>
                 <button type="button" id="restart-chat" class="clear-btn icon-btn" aria-label="Рестарт" title="Рестарт"><i class="fas fa-rotate-right"></i></button>
             </div>
-            <div class="controls">
+                <div class="controls">
                 <select id="model-select">
                     <option data-desc="Стандартен модел за разговор" value="@cf/meta/llama-3.1-8b-instruct">🧠 Разговор</option>
                     <option data-desc="Универсален чат модел" value="@cf/qwen/qwen1.5-7b-chat-awq">🤖 Qwen 1.5-7B</option>
                     <option data-desc="По-голям модел за генерация на текст" value="@hf/thebloke/llama-2-13b-chat-awq">🦙 Llama-2 13B</option>
                     <option data-desc="Многоезичен модел с отлична поддръжка на български. Подходящ за есета и обяснения" value="@cf/google/gemma-3-12b-it">✨ Gemma 3 - 12B</option>
-                    <option data-desc="Mixture-of-Experts модел с висока езикова точност" value="@cf/meta/llama-4-scout-17b-16e-instruct">🚀 LLaMA 4 Scout 17B</option>
+                    <option data-desc="Mixture-of-Experts модел с висока езикова точност" value="@cf/meta/llama-4-scout-17b-16e-instruct" selected>🚀 LLaMA 4 Scout 17B</option>
                     <option data-desc="Силен при структурирано мислене и сложни теми" value="@cf/mistralai/mistral-small-3.1-24b-instruct">🛡 Mistral Small 3.1 24B</option>
                     <option data-desc="Най-мощният модел, подходящ за задълбочени анализи" value="@cf/meta/llama-3.3-70b-instruct-fp8-fast">🏋️ LLaMA 3.3 70B FP8</option>
                     <option data-desc="Компактен и бърз модел" value="@cf/meta/llama-3-8b-instruct">💡 LLaMA 3 - 8B</option>
@@ -45,7 +45,7 @@
                     <option data-desc="Универсален чат модел" value="@cf/qwen/qwen1.5-7b-chat-awq">🤖 Qwen 1.5-7B</option>
                     <option data-desc="По-голям модел за генерация на текст" value="@hf/thebloke/llama-2-13b-chat-awq">🦙 Llama-2 13B</option>
                     <option data-desc="Многоезичен модел с отлична поддръжка на български. Подходящ за есета и обяснения" value="@cf/google/gemma-3-12b-it">✨ Gemma 3 - 12B</option>
-                    <option data-desc="Mixture-of-Experts модел с висока езикова точност" value="@cf/meta/llama-4-scout-17b-16e-instruct">🚀 LLaMA 4 Scout 17B</option>
+                    <option data-desc="Mixture-of-Experts модел с висока езикова точност" value="@cf/meta/llama-4-scout-17b-16e-instruct" selected>🚀 LLaMA 4 Scout 17B</option>
                     <option data-desc="Силен при структурирано мислене и сложни теми" value="@cf/mistralai/mistral-small-3.1-24b-instruct">🛡 Mistral Small 3.1 24B</option>
                     <option data-desc="Най-мощният модел, подходящ за задълбочени анализи" value="@cf/meta/llama-3.3-70b-instruct-fp8-fast">🏋️ LLaMA 3.3 70B FP8</option>
                     <option data-desc="Компактен и бърз модел" value="@cf/meta/llama-3-8b-instruct">💡 LLaMA 3 - 8B</option>
@@ -109,6 +109,13 @@
                     <input type="range" id="delay-level" min="0" max="10" value="3">
                     <span class="value">3</span>
                 </label>
+                <div class="profile-actions">
+                    <select id="profile-select">
+                        <option value="">--Профил--</option>
+                    </select>
+                    <button type="button" id="load-profile">Зареди</button>
+                    <button type="button" id="save-profile">Запази профил</button>
+                </div>
                 <div class="modal-actions">
                     <button type="button" id="save-settings">Запази</button>
                     <button type="button" id="cancel-settings">Отказ</button>

--- a/chat.js
+++ b/chat.js
@@ -51,6 +51,9 @@ const aggressionValue = aggressionInput.nextElementSibling;
 const delayValue = delayInput.nextElementSibling;
 const saveSettingsBtn = document.getElementById('save-settings');
 const cancelSettingsBtn = document.getElementById('cancel-settings');
+const profileSelect = document.getElementById('profile-select');
+const loadProfileBtn = document.getElementById('load-profile');
+const saveProfileBtn = document.getElementById('save-profile');
 const defaultPrompt1 =
     'Ти си {bot1} – защитник на идеята, реда и мъдростта. ' +
     'Вярваш във вечните Форми и във върховенството на разума. ' +
@@ -86,6 +89,7 @@ let menuCollapsed = menuCollapsedStored === 'true';
 if (menuCollapsedStored === null && window.innerWidth < 600) {
     menuCollapsed = true;
 }
+let profiles = JSON.parse(localStorage.getItem('chatProfiles')) || {};
 
 async function loadStoredSettings() {
     try {
@@ -516,6 +520,50 @@ function clearChat() {
     chatHistory.length = 0;
 }
 
+function getSettingsObject() {
+    return {
+        userName, bot1Name, bot2Name,
+        commonPrompt, prompt1, prompt2,
+        length1, temp1, length2, temp2,
+        humorLevel, sarcasmLevel, aggressionLevel, delayLevel,
+        model1: modelSelect.value,
+        model2: modelSelect2.value
+    };
+}
+
+function applyProfile(profile) {
+    if (!profile) return;
+    userNameInput.value = profile.userName || 'Потребител';
+    bot1NameInput.value = profile.bot1Name || 'Платон';
+    bot2NameInput.value = profile.bot2Name || 'Ницше';
+    commonPromptInput.value = profile.commonPrompt || '';
+    prompt1Input.value = profile.prompt1 || defaultPrompt1;
+    prompt2Input.value = profile.prompt2 || defaultPrompt2;
+    length1Input.value = profile.length1 || 60;
+    temp1Input.value = profile.temp1 || 0.7;
+    length2Input.value = profile.length2 || 60;
+    temp2Input.value = profile.temp2 || 0.7;
+    humorInput.value = profile.humorLevel || 0;
+    sarcasmInput.value = profile.sarcasmLevel || 0;
+    aggressionInput.value = profile.aggressionLevel || 0;
+    delayInput.value = profile.delayLevel || 3;
+    if (profile.model1) modelSelect.value = profile.model1;
+    if (profile.model2) modelSelect2.value = profile.model2;
+    updateDescription(modelSelect, modelDesc1);
+    updateDescription(modelSelect2, modelDesc2);
+    applySettings();
+}
+
+function populateProfileSelect() {
+    profileSelect.innerHTML = '<option value="">--Профил--</option>';
+    for (const name of Object.keys(profiles)) {
+        const opt = document.createElement('option');
+        opt.value = name;
+        opt.textContent = name;
+        profileSelect.appendChild(opt);
+    }
+}
+
 function showToast(message) {
     const toast = document.createElement('div');
     toast.className = 'toast';
@@ -615,6 +663,25 @@ cancelSettingsBtn.addEventListener('click', closeSettings);
 saveSettingsBtn.addEventListener('click', () => {
     applySettings();
     closeSettings();
+});
+saveProfileBtn.addEventListener('click', () => {
+    applySettings();
+    const name = prompt('Име на профила:');
+    if (!name) return;
+    profiles[name] = getSettingsObject();
+    localStorage.setItem('chatProfiles', JSON.stringify(profiles));
+    populateProfileSelect();
+    showToast('Профилът е запазен');
+});
+
+loadProfileBtn.addEventListener('click', () => {
+    const name = profileSelect.value;
+    if (!name || !profiles[name]) {
+        showToast('Изберете профил');
+        return;
+    }
+    applyProfile(profiles[name]);
+    showToast('Профилът е зареден');
 });
 promptOverlayClose.addEventListener('click', closePromptEditor);
 promptOverlayText.addEventListener('keydown', (e) => {
@@ -730,4 +797,5 @@ restartBtn.addEventListener('click', () => {
     updateSliderDisplays();
     updateDescription(modelSelect, modelDesc1);
     updateDescription(modelSelect2, modelDesc2);
+    populateProfileSelect();
 })();


### PR DESCRIPTION
## Summary
- set LLaMA 4 Scout as the default model in both selectors
- allow saving and loading of chat settings via new profile actions
- style profile controls inside the settings modal

## Testing
- `node --check chat.js`
- `node --check worker-backend.js`

------
https://chatgpt.com/codex/tasks/task_e_6850cc3491fc83268ac8ee9254b4c929