### PR TITLE
Fix mobile menu layout and overlay height

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -458,6 +458,7 @@ body {
   width: 100%;
   max-width: 800px;
   height: 70vh;
+  max-height: 90vh;
   background: #1e1e1e;
   border: 1px solid #555;
   color: #fff;

--- a/script.js
+++ b/script.js
@@ -39,7 +39,8 @@ const navLinks = document.querySelector('.nav-links');
 
 mobileToggle.addEventListener('click', () => {
     navLinks.classList.toggle('active');
-    mobileToggle.innerHTML = navLinks.classList.contains('active') ? 
+    document.body.classList.toggle('menu-open', navLinks.classList.contains('active'));
+    mobileToggle.innerHTML = navLinks.classList.contains('active') ?
         '<i class="fas fa-times"></i>' : '<i class="fas fa-bars"></i>';
 });
 
@@ -48,6 +49,7 @@ document.querySelectorAll('.nav-links a').forEach(link => {
     link.addEventListener('click', () => {
         if (navLinks.classList.contains('active')) { // Only if menu is active
             navLinks.classList.remove('active');
+            document.body.classList.remove('menu-open');
             mobileToggle.innerHTML = '<i class="fas fa-bars"></i>';
         }
     });

--- a/style.css
+++ b/style.css
@@ -819,20 +819,27 @@ body.dark-theme .mobile-toggle {
         top: 70px; /* Height of header approx */
         left: 0;
         width: 100%;
+        height: calc(100% - 70px);
         background-color: var(--bg-secondary);
         flex-direction: column;
         align-items: center;
+        justify-content: center;
         padding: var(--spacing-lg) 0;
         gap: var(--spacing-md);
+        overflow-y: auto;
         transform: translateY(-150%);
         transition: var(--transition);
         box-shadow: 0 5px 15px var(--shadow);
         z-index: 999; /* Below header but above content */
     }
 
-    body.dark-theme .nav-links {
+body.dark-theme .nav-links {
         background-color: var(--bg-secondary-dark);
         box-shadow: 0 5px 15px var(--shadow-dark);
+    }
+
+    body.menu-open {
+        overflow: hidden;
     }
 
     .nav-links.active {


### PR DESCRIPTION
## Summary
- adjust mobile navigation layout and prevent page scroll while open
- limit prompt overlay textarea height on small screens

## Testing
- `node -c script.js`
- `node -c chat.js`


------
https://chatgpt.com/codex/tasks/task_e_6850cfa9a4508326a08ade25f96fb462