### PR TITLE
Add EMS Acuity report page

### DIFF
--- a/acuity-report.html
+++ b/acuity-report.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EMS Acuity Отчет</title>
+<style>
+  body{
+    font-family: Inter, Roboto, sans-serif;
+    margin:0;
+    padding:20px;
+    background:#f4f4f4;
+    color:#1d1d1d;
+  }
+  h1{
+    text-align:center;
+    margin-bottom:20px;
+  }
+  #filters{
+    display:flex;
+    gap:10px;
+    margin-bottom:20px;
+  }
+  input[type="text"], input[type="date"]{
+    padding:6px 8px;
+    border:1px solid #ccc;
+    border-radius:4px;
+  }
+  table{
+    width:100%;
+    border-collapse:collapse;
+    background:#fff;
+  }
+  th, td{
+    border-bottom:1px solid #ddd;
+    padding:8px;
+  }
+  th{
+    background:#3080f0;
+    color:#fff;
+    position:sticky;
+    top:0;
+    z-index:1;
+  }
+  tbody tr:nth-child(odd){background:#fafafa;}
+  textarea{
+    width:100%;
+    padding:4px;
+    box-sizing:border-box;
+  }
+  button.save{
+    background:#3080f0;
+    color:#fff;
+    border:none;
+    padding:6px 10px;
+    border-radius:4px;
+    cursor:pointer;
+  }
+  #summary{
+    margin-bottom:20px;
+    font-weight:bold;
+  }
+</style>
+</head>
+<body>
+<h1>Отчет за EMS тренировки</h1>
+<div id="summary"></div>
+<div id="filters">
+  <input type="date" id="filterDate">
+  <input type="text" id="filterName" placeholder="Филтър по име">
+</div>
+<div style="overflow-x:auto;">
+<table>
+  <thead>
+    <tr>
+      <th>Дата</th>
+      <th>Час</th>
+      <th>Име на клиент</th>
+      <th>Телефон</th>
+      <th>Цена</th>
+      <th>Бележка</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody id="appointments"></tbody>
+</table>
+</div>
+<script>
+const API_URL = 'https://acuityscheduling.com/api/v1/appointments?appointmentTypeID=80052001';
+const AUTH = 'Basic ' + btoa('13943721:270f72e36bf17ab3074bbcf849f4beb4');
+const PRICE = 40;
+let appointments = [];
+
+function fetchAppointments(){
+  fetch(API_URL,{headers:{'Authorization':AUTH}})
+  .then(r=> r.ok ? r.json() : Promise.reject())
+  .then(data=>{ appointments=data; render(); })
+  .catch(()=>{ appointments=dummyData(); render(); });
+}
+
+function dummyData(){
+  return [
+    {id:1, firstName:'Иван', lastName:'Иванов', phone:'+359888111111', date:'2025-06-24', time:'10:00', datetime:'2025-06-24T10:00:00+0300'},
+    {id:2, firstName:'Мария', lastName:'Петрова', phone:'+359888222222', date:'2025-06-24', time:'11:00', datetime:'2025-06-24T11:00:00+0300'},
+    {id:3, firstName:'Георги', lastName:'Димитров', phone:'+359888333333', date:'2025-06-23', time:'14:00', datetime:'2025-06-23T14:00:00+0300'}
+  ];
+}
+
+function render(){
+  const filterDate=document.getElementById('filterDate').value;
+  const filterName=document.getElementById('filterName').value.toLowerCase();
+  const body=document.getElementById('appointments');
+  body.innerHTML='';
+  let data=[...appointments];
+  data.sort((a,b)=> new Date(b.datetime)-new Date(a.datetime));
+  if(filterDate) data=data.filter(a=> a.date.startsWith(filterDate));
+  if(filterName) data=data.filter(a=> (`${a.firstName} ${a.lastName}`).toLowerCase().includes(filterName));
+  data.forEach(a=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${a.date}</td><td>${a.time}</td><td>${a.firstName} ${a.lastName}</td><td>${a.phone}</td><td>${PRICE.toFixed(2)} лв</td><td><textarea id="note-${a.id}"></textarea></td><td><button class="save" data-id="${a.id}">💾</button></td>`;
+    body.appendChild(tr);
+    const noteEl=tr.querySelector('textarea');
+    noteEl.value=localStorage.getItem('note-'+a.id)||'';
+  });
+  document.querySelectorAll('button.save').forEach(btn=>btn.addEventListener('click',saveNote));
+  updateSummary(data);
+}
+
+function saveNote(e){
+  const id=e.target.getAttribute('data-id');
+  const val=document.getElementById('note-'+id).value;
+  localStorage.setItem('note-'+id,val);
+  e.target.textContent='✅';
+  setTimeout(()=>{e.target.textContent='💾';},1000);
+}
+
+function updateSummary(list){
+  const summary=document.getElementById('summary');
+  const map={};
+  list.forEach(a=>{
+    const d=a.date;
+    if(!map[d]) map[d]=0;
+    map[d]++;
+  });
+  const lines=Object.keys(map).sort((a,b)=> new Date(b)-new Date(a)).map(d=>`${d}: ${map[d]} резервации – ${(map[d]*PRICE).toFixed(2)} лв`);
+  const total=list.length;
+  lines.push(`Общо: ${total} резервации – ${(total*PRICE).toFixed(2)} лв`);
+  summary.innerHTML=lines.join('<br>');
+}
+
+document.getElementById('filterDate').addEventListener('input',render);
+document.getElementById('filterName').addEventListener('input',render);
+
+document.addEventListener('DOMContentLoaded',fetchAppointments);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `acuity-report.html` with inline CSS and JS
  - fetch appointments from Acuity Scheduling API via basic auth
  - display data in a table with notes stored in localStorage
  - provide daily summary and filtering options
  - include fallback dummy data if the API request fails

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b0e5247988326bbe6f29f2c42ec16