### PR TITLE
Enable date range filtering for events

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -9,12 +9,23 @@
 <body>
   <header class="subpage-header">
     <div class="container">
-      <h1>Предстоящи събития</h1>
+      <h1>Събития</h1>
       <nav><a href="main.html">&larr; Начало</a></nav>
     </div>
   </header>
-  <main class="container" id="events-container">
-    <!-- Списъкът с бъдещите събития ще се зареди тук -->
+  <main class="container">
+    <form id="date-filter" class="events-filter">
+      <div class="form-group">
+        <label for="start-date">От:</label>
+        <input type="date" id="start-date">
+      </div>
+      <div class="form-group">
+        <label for="end-date">До:</label>
+        <input type="date" id="end-date">
+      </div>
+      <button id="filter-btn" class="form-submit-btn">Покажи</button>
+    </form>
+    <div id="events-container"><!-- Събитията ще се заредят тук --></div>
   </main>
 
   <script src="calendar.js"></script>

--- a/calendar.js
+++ b/calendar.js
@@ -1,28 +1,67 @@
+let eventsData = [];
+
 async function loadEvents() {
   try {
     const res = await fetch('events.json');
-    const events = await res.json();
-    displayUpcoming(events);
+    eventsData = await res.json();
+    setupDateInputs();
+    filterEvents();
   } catch (err) {
     console.error('Грешка при зареждане на събитията', err);
   }
 }
 
-function displayUpcoming(events) {
+function setupDateInputs() {
+  if (!eventsData.length) return;
+  const startInput = document.getElementById('start-date');
+  const endInput = document.getElementById('end-date');
+
+  const dates = eventsData.map(ev => new Date(ev.date));
+  const minDate = new Date(Math.min(...dates));
+  const maxDate = new Date(Math.max(...dates));
+
+  const format = d => d.toISOString().split('T')[0];
+
+  startInput.min = format(minDate);
+  startInput.max = format(maxDate);
+  endInput.min = format(minDate);
+  endInput.max = format(maxDate);
+
+  startInput.value = format(minDate);
+  endInput.value = format(maxDate);
+
+  document.getElementById('filter-btn').addEventListener('click', e => {
+    e.preventDefault();
+    filterEvents();
+  });
+}
+
+function filterEvents() {
   const container = document.getElementById('events-container');
-  const now = new Date();
-  const upcoming = events
-    .filter(ev => new Date(ev.date) >= now)
+  container.innerHTML = '';
+
+  if (!eventsData.length) return;
+
+  const startVal = document.getElementById('start-date').value;
+  const endVal = document.getElementById('end-date').value;
+  const start = startVal ? new Date(startVal) : null;
+  const end = endVal ? new Date(endVal) : null;
+
+  const filtered = eventsData
+    .filter(ev => {
+      const d = new Date(ev.date);
+      return (!start || d >= start) && (!end || d <= end);
+    })
     .sort((a, b) => new Date(a.date) - new Date(b.date));
 
-  if (!upcoming.length) {
-    container.innerHTML = '<p>Няма предстоящи събития.</p>';
+  if (!filtered.length) {
+    container.innerHTML = '<p>Няма събития в посочения период.</p>';
     return;
   }
 
   const list = document.createElement('ul');
   list.className = 'events-list';
-  upcoming.forEach(ev => {
+  filtered.forEach(ev => {
     const li = document.createElement('li');
     li.innerHTML = `<strong>${ev.title}</strong> - ${ev.date} ${ev.time || ''} (${ev.location})`;
     list.appendChild(li);

--- a/style.css
+++ b/style.css
@@ -912,6 +912,19 @@ body.dark-theme .nav-links {
     text-align: center;
 }
 
+.events-filter {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+    align-items: flex-end;
+}
+
+.events-filter .form-group {
+    display: flex;
+    flex-direction: column;
+}
+
 .events-list {
     list-style: none;
     padding-left: 0;


### PR DESCRIPTION
## Summary
- allow selecting start and end dates in **calendar.html**
- add filtering logic in **calendar.js**
- style the date range form in **style.css**

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bed2433f48326938032323dcbe7e2