### PR TITLE
Add Acuity API proxy endpoint

### DIFF
--- a/acuity-report.html
+++ b/acuity-report.html
@@ -88,13 +88,12 @@
 </table>
 </div>
 <script>
-const API_URL = 'https://acuityscheduling.com/api/v1/appointments?appointmentTypeID=80052001';
-const AUTH = 'Basic ' + btoa('13943721:270f72e36bf17ab3074bbcf849f4beb4');
+const API_ENDPOINT = '/acuity';
 let price = parseFloat(localStorage.getItem('emsPrice')) || 0;
 let appointments = [];
 
 function fetchAppointments(){
-  fetch(API_URL,{headers:{'Authorization':AUTH}})
+  fetch(API_ENDPOINT)
   .then(r=> r.ok ? r.json() : Promise.reject())
   .then(data=>{ appointments=data; render(); })
   .catch(()=>{ appointments=[]; render(); });

--- a/worker-backend.js
+++ b/worker-backend.js
@@ -2,6 +2,36 @@ export default {
   async fetch(request, env) {
     const { pathname } = new URL(request.url);
 
+    if (pathname === '/acuity') {
+      if (request.method !== 'GET') {
+        return new Response('Method Not Allowed', { status: 405 });
+      }
+      const acuityUrl = 'https://acuityscheduling.com/api/v1/appointments?appointmentTypeID=80052001';
+      const auth = 'Basic MTM5NDM3MjE6MjcwZjcyZTM2YmYxN2FiMzA3NGJiY2Y4NDlmNGJlYjQ=';
+      let acuityRes;
+      try {
+        acuityRes = await fetch(acuityUrl, {
+          headers: { 'Authorization': auth }
+        });
+      } catch {
+        return new Response(JSON.stringify({ error: 'Request failed' }), {
+          status: 500,
+          headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*'
+          }
+        });
+      }
+      const result = await acuityRes.text();
+      return new Response(result, {
+        status: acuityRes.status,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*'
+        }
+      });
+    }
+
     if (pathname === '/settings') {
       if (request.method === 'GET') {
         const data = await env.SETTINGS.get('chat', 'json');


### PR DESCRIPTION
## Summary
- add `/acuity` route in `worker-backend.js` which calls the Acuity Scheduling API with Basic Auth
- expose the returned JSON with `Access-Control-Allow-Origin: *`
- fetch from this new endpoint in `acuity-report.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bf0b2b46c832693c088025f9525d6