### PR TITLE
Expose Acuity credentials in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,19 @@ KV. `GET /settings` връща текущите стойности, а `POST /se
 
 ### Acuity отчет
 
-Страницата `acuity-report.html` визуализира записвания от Acuity Scheduling. Данните се зареждат от Worker endpoint `/acuity`, който изисква `calendarID` за търсения календар. API потребителят и ключът трябва да се пазят като Worker secrets, например `ACUITY_USER` и `ACUITY_KEY`.
+`acuity-report.html` вече извиква Acuity API директно от браузъра. Потребителското име и ключът се съхраняват в JavaScript кода и се използват при зареждане на календара.
 
-Примерен достъп:
+Примерен код:
 
-```bash
-curl "https://your-worker.workers.dev/acuity?calendarID=80052001"
+```html
+<script>
+  const ACUITY_USER = '13943721';
+  const ACUITY_KEY = '270f72e36bf17ab3074bbcf849f4beb4';
+  const BASE_URL = 'https://acuityscheduling.com/api/v1';
+  const API_URL = `${BASE_URL}/appointments?appointmentTypeID=80052001&calendarID=12342518`;
+  // извличане на данните ...
+</script>
 ```
+
+Отворете страницата и браузърът ще зареди информацията директно от Acuity.
 

--- a/acuity-report.html
+++ b/acuity-report.html
@@ -88,14 +88,20 @@
 </table>
 </div>
 <script>
-const API_URL =
-  '/acuity?appointmentTypeID=80052001&calendarID=12342518';
+const ACUITY_USER = '13943721';
+const ACUITY_KEY = '270f72e36bf17ab3074bbcf849f4beb4';
+const BASE_URL = 'https://acuityscheduling.com/api/v1';
+const API_URL = `${BASE_URL}/appointments?appointmentTypeID=80052001&calendarID=12342518`;
 let price = parseFloat(localStorage.getItem('emsPrice')) || 0;
 let appointments = [];
 let fetchFailed = false;
 
 function fetchAppointments(){
-  fetch(API_URL)
+  fetch(API_URL, {
+    headers: {
+      'Authorization': 'Basic ' + btoa(`${ACUITY_USER}:${ACUITY_KEY}`)
+    }
+  })
     .then(r => r.ok ? r.json() : Promise.reject())
     .then(data => {
       appointments = data;


### PR DESCRIPTION
## Summary
- fetch Acuity data directly in `acuity-report.html`
- document the new approach in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c303ab300832696c1527cd1292ddb