### PR TITLE
Document Acuity secrets and configurable API url

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ KV. `GET /settings` връща текущите стойности, а `POST /se
 
 Страницата `acuity-report.html` визуализира записвания от Acuity Scheduling. Данните се зареждат от Worker endpoint `/acuity`, който изисква `calendarID` за търсения календар. API потребителят и ключът трябва да се пазят като Worker secrets, например `ACUITY_USER` и `ACUITY_KEY`.
 
+Добавяне на секретите става с `wrangler`:
+
+```bash
+wrangler secret put ACUITY_USER
+wrangler secret put ACUITY_KEY
+```
+
+Тези стойности не бива да се записват във front-end файла. Worker-ът използва секретите, за да извика Acuity API и връща резултата към клиента.
+
 Примерен достъп:
 
 ```bash

--- a/acuity-report.html
+++ b/acuity-report.html
@@ -88,8 +88,12 @@
 </table>
 </div>
 <script>
+// Ако отваряте файла локално или от различен домейн,
+// задайте window.ACUITY_URL = 'https://your-worker.workers.dev/acuity'
+// преди да заредите скрипта.
 const API_URL =
-  '/acuity?appointmentTypeID=80052001&calendarID=12342518';
+  (window.ACUITY_URL || '/acuity') +
+  '?appointmentTypeID=80052001&calendarID=12342518';
 let price = parseFloat(localStorage.getItem('emsPrice')) || 0;
 let appointments = [];
 let fetchFailed = false;


### PR DESCRIPTION
## Summary
- add instructions for setting `ACUITY_USER` and `ACUITY_KEY` secrets in README
- clarify that credentials should not be hardcoded
- allow overriding the Acuity endpoint in `acuity-report.html`

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685c1c9ab7c08326b6e1c5eb32aee7f6