### PR TITLE
Fix Acuity report by specifying Worker URL

### DIFF
--- a/acuity-report.html
+++ b/acuity-report.html
@@ -86,8 +86,13 @@
   </thead>
   <tbody id="appointments"></tbody>
 </table>
-</div>
-<script>
+  </div>
+  <script>
+    // Укажете адреса на вашия Cloudflare Worker, ако отваряте файла локално
+    // или от друг домейн. Заменете "your-worker" с реалното име на Worker-а.
+    window.ACUITY_URL = 'https://your-worker.workers.dev/acuity';
+  </script>
+  <script>
 // Ако отваряте файла локално или от различен домейн,
 // задайте window.ACUITY_URL = 'https://your-worker.workers.dev/acuity'
 // преди да заредите скрипта.


### PR DESCRIPTION
## Summary
- wire up `window.ACUITY_URL` in `acuity-report.html` so local copies know where the backend lives

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c83747174832683508ca22444cc73