### PR TITLE
Update worker URL for Acuity report

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,17 @@ wrangler secret put ACUITY_KEY
 
 Тези стойности не бива да се записват във front-end файла. Worker-ът използва секретите, за да извика Acuity API и връща резултата към клиента.
 
+В `acuity-report.html` задайте променливата `window.ACUITY_URL` с действителния URL на вашия Worker, например:
+
+```html
+<script>
+  window.ACUITY_URL = 'https://workerai.radilov-k.workers.dev/acuity';
+</script>
+```
+
 Примерен достъп:
 
 ```bash
-curl "https://your-worker.workers.dev/acuity?calendarID=80052001"
+curl "https://workerai.radilov-k.workers.dev/acuity?calendarID=80052001"
 ```
 

--- a/acuity-report.html
+++ b/acuity-report.html
@@ -89,12 +89,12 @@
   </div>
   <script>
     // Укажете адреса на вашия Cloudflare Worker, ако отваряте файла локално
-    // или от друг домейн. Заменете "your-worker" с реалното име на Worker-а.
-    window.ACUITY_URL = 'https://your-worker.workers.dev/acuity';
+    // или от друг домейн.
+    window.ACUITY_URL = 'https://workerai.radilov-k.workers.dev/acuity';
   </script>
   <script>
 // Ако отваряте файла локално или от различен домейн,
-// задайте window.ACUITY_URL = 'https://your-worker.workers.dev/acuity'
+// задайте window.ACUITY_URL = 'https://workerai.radilov-k.workers.dev/acuity'
 // преди да заредите скрипта.
 const API_URL =
   (window.ACUITY_URL || '/acuity') +


### PR DESCRIPTION
## Summary
- set `window.ACUITY_URL` in `acuity-report.html`
- document how to configure the Worker URL in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c89ddff3c8326bc8a5d5ca7a26b94