### PR TITLE
Fix LLaMA 3 runModel usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,20 @@ KV. `GET /settings` връща текущите стойности, а `POST /se
 #### Примерна Node.js заявка към LLaMA 3.3 70B
 
 ```javascript
-const model = '@cf/meta/llama-3.3-70b-instruct-fp8-fast'; // FTN = free
-const response = await ai.run(model, {
+const ai = new Ai(env.AI);
+const model = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
+const result = await ai.runModel(model, {
   messages: [
     { role: 'user', content: 'Обясни на български какво е фотосинтеза.' }
   ],
-  max_tokens: 16000
+  max_tokens: 300
 });
+
+console.log(result.response); // "Фотосинтезата е процес при който..."
 ```
+
+Методът `runModel()` връща обект с ключ `response`. Използвайте масив `messages`,
+тъй като моделът очаква диалогов формат.
 
 ### Acuity отчет
 

--- a/chat.js
+++ b/chat.js
@@ -432,16 +432,16 @@ async function sendRequest(model, messages, displayRole, speaker, fileData, temp
         });
         const data = await response.json();
         if (model === '@cf/flux-1-schnell') {
-            const img = data.result.response;
+            const img = data.response || data.result?.response;
             appendImageMessage(displayRole, img);
             return '[image]';
         }
         if (model === '@cf/openai/whisper-large-v3') {
-            const text = data.result.transcription;
+            const text = data.text || data.transcription || data.result?.transcription;
             appendMessage(displayRole, text, speaker);
             return text;
         }
-        let aiText = data.result.response;
+        let aiText = data.response || (data.result && data.result.response);
         const escaped = participantNames().map(escapeRegExp).join('|');
         const nameRegex = new RegExp(`^(${escaped}):?\\s*`, 'i');
         aiText = aiText.replace(nameRegex, '');
@@ -529,7 +529,7 @@ async function transcribeAudio(blob) {
             body: JSON.stringify(payload)
         });
         const data = await response.json();
-        return data.result.transcription;
+        return data.text || data.transcription || data.result?.transcription;
     } catch {
         appendMessage('assistant', 'Грешка при транскрипция.');
         return null;

--- a/worker-backend.js
+++ b/worker-backend.js
@@ -1,3 +1,5 @@
+import { Ai } from '@cloudflare/ai';
+
 export default {
   async fetch(request, env) {
     const { pathname } = new URL(request.url);
@@ -99,22 +101,14 @@ export default {
       return new Response('Invalid JSON', { status: 400 });
     }
 
-    // ПРОМЕНЕН САМО ТОЗИ ФРАГМЕНТ:
     const model = data.model || env.MODEL;
-    const cfEndpoint = `https://api.cloudflare.com/client/v4/accounts/${env.ACCOUNT_ID}/ai/run/${model}`;
-    // payload е вече копие на целия data обект, т.е. всичко подадено от клиента:
-    const payload = { ...data };
+    const options = { ...data };
+    delete options.model;
 
-    let response;
+    const ai = new Ai(env.AI);
+    let result;
     try {
-      response = await fetch(cfEndpoint, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${env.AI_TOKEN}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(payload)
-      });
+      result = await ai.runModel(model, options);
     } catch (err) {
       return new Response(JSON.stringify({ error: 'Request failed' }), {
         status: 500,
@@ -125,9 +119,8 @@ export default {
       });
     }
 
-    const result = await response.text();
-    return new Response(result, {
-      status: response.status,
+    return new Response(JSON.stringify(result), {
+      status: 200,
       headers: {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Origin': '*'


### PR DESCRIPTION
## Summary
- update the README example for the LLaMA 3.3 70B model to use `Ai.runModel`
- move worker code to `Ai.runModel` and adjust frontend parsing

## Testing
- `node --check worker-backend.js`
- `node --check chat.js`


------
https://chatgpt.com/codex/tasks/task_e_6874496a69e88326a938e8b28c388acf