### PR TITLE
Добавяне на KV namespace SETTINGS

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,3 +4,7 @@ compatibility_date = "2024-07-01"
 
 [[ai]]
 binding = "AI"
+
+[[kv_namespaces]]
+binding = "SETTINGS"
+id = "<your_kv_id>"


### PR DESCRIPTION
## Резюме
- добавен е раздел `kv_namespaces` с binding `SETTINGS` и placeholder за ID

## Тестване
- `npx --yes wrangler@4.28.1 --config=/tmp/empty.toml kv namespace list` *(проваля се: изисква CLOUDFLARE_API_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_689794b296a08326a1625ca35c89b84e