### PR TITLE
IntoDesign: wide desktop header fix and team photo display

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -615,7 +615,7 @@
                         ${field('Телефон', '', textInput(`team.members.${i}.phone`, m.phone))}
                         ${field('Имейл', '', textInput(`team.members.${i}.email`, m.email))}
                     </div>
-                    ${imageField(`team.members.${i}.image`, m.image, 'Снимка', 'Портретен формат 3:4 — лицето трябва да е изцяло видимо. Снимката се показва без изрязване.')}
+                    ${imageField(`team.members.${i}.image`, m.image, 'Снимка', 'Портрет 3:4 препоръчителен. Снимката се показва изцяло върху фона на страницата — без рамка и без изрязване.')}
                 </div>
             </div>`).join('');
 

--- a/main.html
+++ b/main.html
@@ -78,30 +78,32 @@
 
     <!-- Top Header Bar -->
     <header class="top-header" id="topHeader">
-        <div class="top-header-left">
-            <a href="#" class="mobile-logo" aria-label="IntoDesign Studio">
-                <span class="mobile-logo-text">INTO</span>
-                <span class="mobile-logo-sub">design studio</span>
-            </a>
-            <nav class="page-scroll-nav" aria-label="Секции">
-                <ul>
-                    <li><a href="#" class="act-link" data-section="home">Начало</a></li>
-                    <li><a href="#about" data-section="about">За нас</a></li>
-                    <li><a href="#portfolio" data-section="portfolio">Проекти</a></li>
-                    <li><a href="#services" data-section="services">Услуги</a></li>
-                    <li><a href="#contact" data-section="contact">Контакт</a></li>
-                </ul>
-            </nav>
-        </div>
-        <div class="top-header-center">
-            <span class="header-tagline" id="headerSubtitle">Архитектура · Дизайн · Интериор</span>
-        </div>
-        <div class="top-header-right">
-            <a href="#contact" class="top-header-cta" id="headerCta"><i class="fas fa-envelope"></i> <span>Свържете се</span></a>
-            <button class="nav-button but-hol" id="navToggle" aria-label="Меню" aria-expanded="false">
-                <span class="menu-burger"><span></span><span></span><span></span></span>
-                <span class="menu-text">Menu</span>
-            </button>
+        <div class="top-header-inner">
+            <div class="top-header-left">
+                <a href="#" class="mobile-logo" aria-label="IntoDesign Studio">
+                    <span class="mobile-logo-text">INTO</span>
+                    <span class="mobile-logo-sub">design studio</span>
+                </a>
+                <nav class="page-scroll-nav" aria-label="Секции">
+                    <ul>
+                        <li><a href="#" class="act-link" data-section="home">Начало</a></li>
+                        <li><a href="#about" data-section="about">За нас</a></li>
+                        <li><a href="#portfolio" data-section="portfolio">Проекти</a></li>
+                        <li><a href="#services" data-section="services">Услуги</a></li>
+                        <li><a href="#contact" data-section="contact">Контакт</a></li>
+                    </ul>
+                </nav>
+            </div>
+            <div class="top-header-center">
+                <span class="header-tagline" id="headerSubtitle">Архитектура · Дизайн · Интериор</span>
+            </div>
+            <div class="top-header-right">
+                <a href="#contact" class="top-header-cta" id="headerCta"><i class="fas fa-envelope"></i> <span>Свържете се</span></a>
+                <button class="nav-button but-hol" id="navToggle" aria-label="Меню" aria-expanded="false">
+                    <span class="menu-burger"><span></span><span></span><span></span></span>
+                    <span class="menu-text">Menu</span>
+                </button>
+            </div>
         </div>
         <div class="scroll-progress-bar">
             <div class="scroll-progress-fill" id="scrollProgress"></div>

--- a/style.css
+++ b/style.css
@@ -399,10 +399,17 @@ ul {
     background: var(--dark-1);
     border-bottom: 1px solid rgba(255,255,255,0.05);
     z-index: 99;
+}
+
+.top-header-inner {
+    max-width: 1280px;
+    height: 100%;
+    margin: 0 auto;
+    padding: 0 32px;
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    grid-template-columns: auto 1fr auto;
     align-items: center;
-    padding: 0 30px;
+    gap: 24px;
 }
 
 .top-header-left {
@@ -1611,10 +1618,7 @@ ul {
     overflow: hidden;
     margin-bottom: 20px;
     aspect-ratio: 3 / 4;
-    background: #ececec;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    background: transparent;
 }
 
 .team-photo img {
@@ -1622,28 +1626,16 @@ ul {
     height: 100%;
     object-fit: contain;
     object-position: center center;
-    transition: filter 0.5s ease;
-    filter: grayscale(0%);
+    transition: transform 0.6s ease;
+    display: block;
 }
 
 .team-box:hover .team-photo img {
-    filter: grayscale(100%);
+    transform: scale(1.08);
 }
 
 .team-photo .overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: #000;
-    opacity: 0;
-    transition: opacity 0.5s ease;
-    z-index: 2;
-}
-
-.team-box:hover .overlay {
-    opacity: 0.3;
+    display: none;
 }
 
 .team-social {
@@ -2540,12 +2532,20 @@ textarea:focus-visible {
         display: none;
     }
 
-    .top-header {
+    .top-header-inner {
         grid-template-columns: 1fr auto;
+        gap: 16px;
     }
 
     .page-scroll-nav ul {
         gap: 18px;
+    }
+}
+
+/* Wide desktop — contained header content */
+@media (min-width: 1141px) {
+    .top-header-inner {
+        max-width: min(1280px, calc(100vw - var(--sidebar-w) - 48px));
     }
 }
 
@@ -2610,8 +2610,13 @@ textarea:focus-visible {
     .top-header {
         left: 0;
         height: var(--topbar-h);
+    }
+
+    .top-header-inner {
+        max-width: none;
         grid-template-columns: 1fr auto;
         padding: 0 16px 0 0;
+        gap: 12px;
     }
 
     .top-header-left {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Latest fixes

### Wide desktop header
- Inner container `top-header-inner` max-width 1280px, centered
- Grid `auto | 1fr | auto` — nav compact left, tagline centered, CTA+menu right
- Fixes broken layout on ultrawide monitors (separate from tablet/mobile)

### Team photos
- Transparent background — blends with page, no gray box/frame
- `object-fit: contain` — full image preserved
- Hover: zoom 1.08x like portfolio (grayscale removed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97b1664c-3e02-4b80-bbfb-96778ef1fddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97b1664c-3e02-4b80-bbfb-96778ef1fddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

