### PR TITLE
Set up local development environment (dev wrangler config + AGENTS.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Thumbs.db
 .idea/
 *.swp
 *.swo
+
+# Wrangler local dev state/cache
+.wrangler/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a **static frontend** (plain HTML/CSS/JS, deployed to GitHub Pages) plus a
+**Cloudflare Worker backend** (`worker.js`, deployed with Wrangler). There is no
+`package.json`, no build step, and no automated test suite. Node 22, Python 3, and
+`wrangler` (via `npx`) are available.
+
+### Services
+
+| Service | How to run | Notes |
+| --- | --- | --- |
+| Static site (primary product) | `python3 -m http.server 8000` from repo root | Entry page is `main.html` (the IntoDesign portfolio site); `index.html` redirects to it. Other pages: `client-portal.html`, `acuity-manager.html`, `admin.html`, `chat.html`. |
+| Worker backend API | `npx wrangler dev -c wrangler.dev.toml --port 8787` | Serves the Client Portal / CMS / Acuity API (routes under `/api/...`). |
+
+### Important caveats (non-obvious)
+
+- **Use `wrangler.dev.toml`, NOT the committed `wrangler.toml`, for local dev.** The
+  production `wrangler.toml` uses the legacy `[[ai]]` array binding syntax, which modern
+  Wrangler (v3/v4) rejects with `The field "ai" should be an object`. `worker.js` (the
+  configured `main`) does not use the AI binding, so `wrangler.dev.toml` omits it and uses
+  local placeholder KV namespace ids. Do not "fix" `wrangler.toml` casually — it reflects the
+  production deploy config.
+- `wrangler dev` runs the Worker against a **local** simulated KV store, so no real
+  Cloudflare account or KV ids are needed. Data does not persist to production.
+- The CMS admin password defaults to `intodesign2024` (`SITE_ADMIN_PASSWORD` env override).
+  Useful for testing `/api/site-auth`.
+- Acuity Scheduling endpoints (`/api/me`, `/api/availability`, `/api/book`, etc.) require
+  `ACUITY_USER_ID`/`ACUITY_API_KEY` (or legacy `ACUITY_USER`/`ACUITY_KEY`) secrets and call the
+  live Acuity API; they return errors without those credentials. The CMS/inquiry endpoints
+  (`/api/health`, `/api/site-auth`, `/api/site-content`, `/api/inquiries`) work fully locally.
+- "Lint" / "test": there is no configured linter or test runner. The closest available check
+  is `node --check <file.js>` for JS syntax.

--- a/wrangler.dev.toml
+++ b/wrangler.dev.toml
@@ -1,0 +1,19 @@
+# Local development config for `wrangler dev` (the Client Portal backend in worker.js).
+#
+# The committed production `wrangler.toml` uses the legacy `[[ai]]` array syntax,
+# which modern Wrangler (v3/v4) rejects. `worker.js` does not use the AI binding
+# (that lives in worker-backend.js), so this dev config simply omits it and uses
+# local placeholder KV namespace ids that Wrangler simulates on disk.
+#
+# Usage:  npx wrangler dev -c wrangler.dev.toml --port 8787
+name = "worker-backend"
+main = "worker.js"
+compatibility_date = "2024-07-01"
+
+[[kv_namespaces]]
+binding = "SETTINGS"
+id = "settings_local_dev"
+
+[[kv_namespaces]]
+binding = "APP_KV"
+id = "app_kv_local_dev"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the local development environment for this static frontend + Cloudflare Worker project. No application code was modified.

- Adds `wrangler.dev.toml`, a dev-only Wrangler config for running `worker.js` locally. The committed production `wrangler.toml` uses the legacy `[[ai]]` array syntax that modern Wrangler (v3/v4) rejects; `worker.js` does not use the AI binding, so the dev config omits it and uses local placeholder KV ids.
- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting how to run each service and key gotchas.

## How to run

- Static site (primary product): `python3 -m http.server 8000` → open `http://localhost:8000/main.html`
- Worker backend: `npx wrangler dev -c wrangler.dev.toml --port 8787`

## Testing

- `node --check` passes on all JS files.
- Worker API verified locally: `/api/health`, `/api/site-auth` (pw `intodesign2024`), and an end-to-end inquiry submit + authenticated retrieve via `/api/inquiries`.
- GUI walkthrough of the running portfolio site: navigation, project lightbox, and contact form interaction.

[intodesign_site_walkthrough.mp4](https://cursor.com/agents/bc-d2eb3e54-013a-4378-8b2f-4ef844cefdc5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintodesign_site_walkthrough.mp4)

[Project lightbox](https://cursor.com/agents/bc-d2eb3e54-013a-4378-8b2f-4ef844cefdc5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_project_lightbox.webp)
[Contact form](https://cursor.com/agents/bc-d2eb3e54-013a-4378-8b2f-4ef844cefdc5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_contact_form.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2eb3e54-013a-4378-8b2f-4ef844cefdc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2eb3e54-013a-4378-8b2f-4ef844cefdc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

