### PR TITLE
Archimak desktop header, wide-screen layout, unified logo

### DIFF
--- a/main.html
+++ b/main.html
@@ -31,11 +31,9 @@
     <!-- Fixed Left Sidebar (desktop) -->
     <aside class="main-header" aria-label="Странична лента">
         <div class="logo-holder">
-            <a href="#" class="logo-link" aria-label="IntoDesign Studio">
-                <div class="logo-text">
-                    <span>I</span><span>N</span><span>T</span><span>O</span>
-                </div>
-                <span class="logo-sub">design studio</span>
+            <a href="#" class="logo-link site-logo" aria-label="IntoDesign Studio">
+                <span class="mobile-logo-text">INTO</span>
+                <span class="mobile-logo-sub">design studio</span>
             </a>
         </div>
         <div class="header-social">
@@ -80,7 +78,7 @@
     <header class="top-header" id="topHeader">
         <div class="top-header-inner">
             <div class="top-header-left">
-                <a href="#" class="mobile-logo" aria-label="IntoDesign Studio">
+                <a href="#" class="mobile-logo site-logo" aria-label="IntoDesign Studio">
                     <span class="mobile-logo-text">INTO</span>
                     <span class="mobile-logo-sub">design studio</span>
                 </a>

--- a/style.css
+++ b/style.css
@@ -167,43 +167,38 @@ ul {
     flex-shrink: 0;
 }
 
-.logo-link {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-}
-
-.logo-text {
+.logo-link.site-logo,
+.site-logo {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1px;
+    justify-content: center;
+    line-height: 1.1;
+    text-align: center;
+    text-decoration: none;
 }
 
-.logo-text span {
+.logo-holder .logo-link.site-logo {
+    width: 100%;
+    height: 100%;
+    padding: 0 6px;
+}
+
+.mobile-logo-text {
     font-family: 'Teko', sans-serif;
-    font-size: 13px;
+    font-size: 22px;
     font-weight: 700;
     color: #fff;
-    line-height: 1;
     letter-spacing: 3px;
+    line-height: 1;
 }
 
-.logo-sub {
-    font-family: 'Mukta Vaani', sans-serif;
-    font-size: 7px;
-    letter-spacing: 0.15em;
+.mobile-logo-sub {
+    font-size: 9px;
+    letter-spacing: 0.2em;
     text-transform: lowercase;
     color: var(--accent);
-    margin-top: 3px;
-    writing-mode: vertical-rl;
-    text-orientation: mixed;
-    position: absolute;
-    right: -2px;
-    top: 50%;
-    transform: translateY(-50%) rotate(180deg);
-    opacity: 0.8;
+    line-height: 1.2;
 }
 
 .header-social {
@@ -425,26 +420,12 @@ ul {
     display: none;
     flex-direction: column;
     justify-content: center;
+    align-items: flex-start;
     line-height: 1.1;
     flex-shrink: 0;
     height: var(--topbar-h);
     padding: 0 20px;
     border-right: 1px solid rgba(255,255,255,0.1);
-}
-
-.mobile-logo-text {
-    font-family: 'Teko', sans-serif;
-    font-size: 22px;
-    font-weight: 700;
-    color: #fff;
-    letter-spacing: 3px;
-}
-
-.mobile-logo-sub {
-    font-size: 9px;
-    letter-spacing: 0.2em;
-    text-transform: lowercase;
-    color: var(--accent);
 }
 
 .top-header-center {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Възстановен Archimak десктоп хедър, поправени wide-screen/fullscreen layout проблеми и унифицирано логото.

### Desktop header (≥1065px)
- Лява sidebar лента с INTO лого и социални линкове
- Горен хедър: section nav, tagline (от 1500px+), CTA, Menu
- Full-bleed header — nav вляво, actions вдясно (без 1320px „плуваща“ кутия)
- Споделен `--content-pad-x` за подравняване на header, hero и секции

### Mobile (≤1064px)
- Компактен хедър: INTO logo + Menu
- Sidebar, inline nav, tagline и CTA скрити

### Logo
- Sidebar и mobile header ползват **еднакъв** вид: `INTO` + `design studio`
- Премахнато старото вертикално I/N/T/O лого на десктоп

### Други
- Admin panel, inquiries, team photos, 360° view — запазени
- Revert на грешния unified mobile-only header (`ee86b4b`)

## Commits
- `bf07c16` — Restore desktop Archimak header
- `f4bfbb6` — Fix wide-screen fullscreen layout
- `78edb7c` — Unify desktop sidebar logo with mobile-logo style
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97b1664c-3e02-4b80-bbfb-96778ef1fddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97b1664c-3e02-4b80-bbfb-96778ef1fddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

